### PR TITLE
Add health endpoint

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,0 +1,5 @@
+class HealthController < ActionController::API
+  def show
+    render plain: 'healthy'
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,6 @@ Rails.application.routes.draw do
   scope 'v1' do
     resources :complaint, only: [:create]
   end
+
+  get '/health', to: 'health#show'
 end

--- a/spec/controllers/health_controller_spec.rb
+++ b/spec/controllers/health_controller_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe HealthController do
+  describe 'GET #show' do
+    it 'returns 200 OK' do
+      get :show
+      expect(response.body).to eq('healthy')
+      expect(response.status).to eq(200)
+    end
+  end
+end

--- a/spec/controllers/health_controller_spec.rb
+++ b/spec/controllers/health_controller_spec.rb
@@ -2,10 +2,16 @@ require 'rails_helper'
 
 describe HealthController do
   describe 'GET #show' do
-    it 'returns 200 OK' do
+    before do
       get :show
-      expect(response.body).to eq('healthy')
+    end
+
+    it 'returns 200 OK' do
       expect(response.status).to eq(200)
+    end
+
+    it 'returns the text "healthy"' do
+      expect(response.body).to eq('healthy')
     end
   end
 end


### PR DESCRIPTION
Kubernetes will use this to do rolling deployments, ensuring that the
application is running as opposed to just the pod being booted.