### PR TITLE
Expose health endpoint for Kubernetes rolling deploys

### DIFF
--- a/deploy/templates/deployment.yaml
+++ b/deploy/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: hmcts-complaints-formbuilder-adapter
 spec:
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:
@@ -15,6 +15,13 @@ spec:
         imagePullPolicy: Always
         ports:
         - containerPort: 3000
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 3000
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
         env:
         - name: SECRET_KEY_BASE
           valueFrom:


### PR DESCRIPTION
This will ensure that the application is ready and not just the pod