### PR TITLE
Fix up typo in deployment manifest

### DIFF
--- a/deploy/templates/deployment.yaml
+++ b/deploy/templates/deployment.yaml
@@ -28,7 +28,6 @@ spec:
             secretKeyRef:
               name: hmcts-complaints-formbuilder-adapter-secret
               key: SECRET_KEY_BASE
-        env:
         - name: JWE_SHARED_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
This secret_key_base was never being set as an env variable in the pod.
This is because there is a duplicate env definition.
Remove this.