### PR TITLE
Build job worker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ workflows:
     jobs:
       - test
       - aws-ecr/build-and-push-image:
-          name: push_app_image #todo remove ECR_ENDPOINT var as it is not used
+          name: push_app_image
           dockerfile: Dockerfile
           account-url: AWS_ECR_ACCOUNT_URL
           region: AWS_DEFAULT_REGION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
-  aws-ecr: circleci/aws-ecr@0.0.2
+  aws-ecr: circleci/aws-ecr@6.3.0
+
 jobs:
   test:
     working_directory: ~/circle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
             - "7e:e7:44:be:a1:4b:4e:3c:56:65:3a:94:19:50:02:cc"
       - run:
           name: deploy to staging
-          command: './deploy/scripts/circle_deploy.sh staging $KUBE_TOKEN_STAGING'
+          command: './deploy/scripts/circle_deploy.sh "APP_${CIRCLE_SHA1}" staging $KUBE_TOKEN_STAGING'
 
   deploy_production:
     working_directory: ~/circle/git/hmcts-complaints-formbuilder-adapter
@@ -42,7 +42,7 @@ jobs:
             - "7e:e7:44:be:a1:4b:4e:3c:56:65:3a:94:19:50:02:cc"
       - run:
           name: deploy to production
-          command: './deploy/scripts/circle_deploy.sh production $KUBE_TOKEN_PRODUCTION'
+          command: './deploy/scripts/circle_deploy.sh "APP_${CIRCLE_SHA1}" production $KUBE_TOKEN_PRODUCTION'
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,18 @@ workflows:
     jobs:
       - test
       - aws-ecr/build_and_push_image:
+          name: push_app_image
+          dockerfile: Dockerfile
+          account-url: "754256621582.dkr.ecr.eu-west-2.amazonaws.com"
+          repo: "form-builder/hmcts-complaints-formbuilder-adapter"
+          region: ${AWS_DEFAULT_REGION}
+          tag: "${CIRCLE_SHA1}"
+          filters:
+            branches:
+              only: master
+      - aws-ecr/build_and_push_image:
+          name: push_worker_image
+          dockerfile: Dockerfile.worker
           account-url: "754256621582.dkr.ecr.eu-west-2.amazonaws.com"
           repo: "form-builder/hmcts-complaints-formbuilder-adapter"
           region: ${AWS_DEFAULT_REGION}
@@ -59,7 +71,8 @@ workflows:
               only: master
       - deploy_staging:
           requires:
-            - aws-ecr/build_and_push_image
+            - push_app_image
+            - push_worker_image
             - test
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,23 +49,23 @@ workflows:
   release:
     jobs:
       - test
-      - aws-ecr/build_and_push_image:
-          name: push_app_image
+      - aws-ecr/build-and-push-image:
+          name: push_app_image #todo remove ECR_ENDPOINT var as it is not used
           dockerfile: Dockerfile
-          account-url: "754256621582.dkr.ecr.eu-west-2.amazonaws.com"
+          account-url: AWS_ECR_ACCOUNT_URL
+          region: AWS_DEFAULT_REGION
           repo: "form-builder/hmcts-complaints-formbuilder-adapter"
-          region: ${AWS_DEFAULT_REGION}
-          tag: "${CIRCLE_SHA1}"
+          tag: "APP_${CIRCLE_SHA1}"
           filters:
             branches:
               only: master
-      - aws-ecr/build_and_push_image:
+      - aws-ecr/build-and-push-image:
           name: push_worker_image
           dockerfile: Dockerfile.worker
-          account-url: "754256621582.dkr.ecr.eu-west-2.amazonaws.com"
+          account-url: AWS_ACCOUNT_URL
+          region: AWS_DEFAULT_REGION
           repo: "form-builder/hmcts-complaints-formbuilder-adapter"
-          region: ${AWS_DEFAULT_REGION}
-          tag: "${CIRCLE_SHA1}"
+          tag: "WORKER_${CIRCLE_SHA1}"
           filters:
             branches:
               only: master

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,0 +1,27 @@
+FROM ruby:2.6.4-alpine3.9
+
+ARG UID
+
+RUN apk add build-base postgresql-contrib postgresql-dev bash tzdata
+
+RUN addgroup -g 1001 -S appgroup && \
+  adduser -u 1001 -S appuser -G appgroup
+
+WORKDIR /app
+ENV HOME /app
+
+COPY Gemfile* .ruby-version ./
+
+RUN gem install bundler
+RUN bundle install --no-cache
+
+COPY . .
+
+RUN chown -R 1001:appgroup /app
+
+USER 1001
+
+ARG RAILS_ENV='production'
+ENV RAILS_ENV=$RAILS_ENV
+
+CMD bin/delayed_job run

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -24,4 +24,4 @@ USER 1001
 ARG RAILS_ENV='production'
 ENV RAILS_ENV=$RAILS_ENV
 
-CMD bin/delayed_job run
+CMD bin/delayed_job --queue=send_complaints run

--- a/deploy/scripts/circle_deploy.sh
+++ b/deploy/scripts/circle_deploy.sh
@@ -3,6 +3,8 @@
 set -e -u -o pipefail
 
 CONFIG_FILE="/tmp/helm_deploy.yaml"
+
+image_tag=$1
 environment_name=$1
 kube_token=$2
 
@@ -20,7 +22,7 @@ deploy_with_secrets() {
     kubectl config use-context "circleci_${environment_name}"
 
     helm template deploy/ \
-         --set circleSha1=$CIRCLE_SHA1 \
+         --set imagetag=$image_tag \
          --set environmentName=$environment_name \
          > $CONFIG_FILE
 

--- a/deploy/templates/deployment.yaml
+++ b/deploy/templates/deployment.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: hmcts-complaints-formbuilder-adapter
-        image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/form-builder/hmcts-complaints-formbuilder-adapter:{{ .Values.circleSha1 }}
+        image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/form-builder/hmcts-complaints-formbuilder-adapter:{{ .Values.imagetag }}
         imagePullPolicy: Always
         ports:
         - containerPort: 3000


### PR DESCRIPTION
- adds a new step to build the new 'worker' image
- prefixes tags with the type of image
- changes deploy scripts so that deploy tag is passed down

*New image is uploaded but not deployed to envs yet*

