### PR TITLE
Add reference and location to payload

### DIFF
--- a/app/lib/presenter/complaint.rb
+++ b/app/lib/presenter/complaint.rb
@@ -8,7 +8,8 @@ module Presenter
       {
         RequestDate: @data.fetch(:submissionDate, Date.today),
         Details: @data.fetch(:complaint_details, ''),
-        Location: @data.fetch(:complaint_location, '')
+        Location: @data.fetch(:complaint_location, ''),
+        Reference: @data.fetch(:case_number, '')
       }.merge(constant_data, customer_data)
     end
 

--- a/spec/presenter/complaint_spec.rb
+++ b/spec/presenter/complaint_spec.rb
@@ -15,7 +15,8 @@ describe Presenter::Complaint do
         'postcode': 'SW1H 9AJ',
         'complaint_details': 'I lost my case',
         'complaint_location': '1021',
-        'submissionDate': '1568199892316'
+        'submissionDate': '1568199892316',
+        'case_number': '12345'
       }
     }
   end
@@ -28,6 +29,7 @@ describe Presenter::Complaint do
       RequestMethod: 'Form',
       RequestDate: '1568199892316',
       Team: 'INBOX',
+      Reference: '12345',
       "Customer.FirstName": 'Jim',
       "Customer.Surname": 'Complainer',
       "Customer.Address": '102 Petty France',
@@ -61,6 +63,7 @@ describe Presenter::Complaint do
         db: 'hmcts',
         Type: 'Complaint',
         Format: 'json',
+        Reference: '',
         RequestMethod: 'Form',
         RequestDate: Date.today,
         Team: 'INBOX',

--- a/spec/requests/complaint_spec.rb
+++ b/spec/requests/complaint_spec.rb
@@ -27,6 +27,7 @@ describe 'Submitting a complaint', type: :request do
       RequestDate: Date.today,
       Details: '',
       Location: '',
+      Reference: '',
       db: 'hmcts',
       Type: 'Complaint',
       Format: 'json',


### PR DESCRIPTION
Case number now saving as reference in Optics.

Location is being passed along, but not being saved in Optics. We'll have to get more information on how to send this to the API. For now it can just stay present in the payload.