### PR TITLE
Switch cases to delayed job

### DIFF
--- a/app/controllers/complaint_controller.rb
+++ b/app/controllers/complaint_controller.rb
@@ -1,24 +1,7 @@
 class ComplaintController < ApplicationController
   def create
-    Usecase::Optics::CreateCase.new(
-      optics_gateway: Gateway::Optics.new,
-      presenter: Presenter::Complaint.new(form_builder_payload: @decrypted_body),
-      get_bearer_token: bearer_token
-    ).execute
+    SendComplaintJob.perform_later(form_builder_payload: @decrypted_body)
 
     render json: { placeholder: true }, status: 201
-  end
-
-  private
-
-  def bearer_token
-    Usecase::Optics::GetBearerToken.new(
-      optics_gateway: Gateway::Optics.new,
-      generate_jwt_token: Usecase::Optics::GenerateJwtToken.new(
-        url: 'https://uat.icasework.com/token?db=hmcts',
-        api_key: Rails.configuration.x.optics.api_key,
-        hmac_secret: Rails.configuration.x.optics.secret_key
-      )
-    )
   end
 end

--- a/app/jobs/send_complaint_job.rb
+++ b/app/jobs/send_complaint_job.rb
@@ -1,5 +1,28 @@
 class SendComplaintJob < ApplicationJob
   queue_as :send_complaints
 
-  def perform; end
+  def perform(form_builder_payload:)
+    Usecase::Optics::CreateCase.new(
+      optics_gateway: Gateway::Optics.new,
+      presenter: Presenter::Complaint.new(form_builder_payload: form_builder_payload),
+      get_bearer_token: bearer_token
+    ).execute
+  end
+
+  private
+
+  def bearer_token
+    Usecase::Optics::GetBearerToken.new(
+      optics_gateway: Gateway::Optics.new,
+      generate_jwt_token: generate_token
+    )
+  end
+
+  def generate_token
+    Usecase::Optics::GenerateJwtToken.new(
+      url: 'https://uat.icasework.com/token?db=hmcts',
+      api_key: Rails.configuration.x.optics.api_key,
+      hmac_secret: Rails.configuration.x.optics.secret_key
+    )
+  end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,19 +34,19 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
-  # Raises error for missing translations.
-  # config.action_view.raise_on_missing_translations = true
+  # default async active job backend, uses an in-process thread pool
+  config.active_job.queue_adapter = ActiveJob::QueueAdapters::AsyncAdapter.new(
+    min_threads: 1,
+    max_threads: 2 * Concurrent.processor_count,
+    idletime: 600.seconds
+  )
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.shared_key =
-    ENV.fetch('DEVELOPMENT_JWE_SHARED_KEY', '5d6dc7fc083ea4f0'.freeze)
+  config.shared_key = ENV.fetch('DEVELOPMENT_JWE_SHARED_KEY', '5d6dc7fc083ea4f0'.freeze)
 
-  config.x.optics.secret_key =
-    ENV.fetch('OPTICS_SECRET_KEY', SecureRandom.hex(8).freeze)
-
-  config.x.optics.api_key =
-    ENV.fetch('OPTICS_API_KEY', SecureRandom.hex(8).freeze)
+  config.x.optics.secret_key = ENV.fetch('OPTICS_SECRET_KEY', SecureRandom.hex(8).freeze)
+  config.x.optics.api_key = ENV.fetch('OPTICS_API_KEY', SecureRandom.hex(8).freeze)
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,13 @@ Rails.application.configure do
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
-  config.active_job.queue_adapter = :delayed_job
+  # config.active_job.queue_adapter = :delayed_job
+
+  config.active_job.queue_adapter = ActiveJob::QueueAdapters::AsyncAdapter.new(
+    min_threads: 1,
+    max_threads: 2 * Concurrent.processor_count,
+    idletime: 600.seconds
+  )
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -34,6 +34,8 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
+  config.active_job.queue_adapter = :test
+
   config.shared_key =
     ENV.fetch('TEST_JWE_SHARED_KEY', SecureRandom.hex(8).freeze)
 

--- a/spec/jobs/send_complaint_job_spec.rb
+++ b/spec/jobs/send_complaint_job_spec.rb
@@ -1,12 +1,44 @@
 require 'rails_helper'
 
-RSpec.describe SendComplaintJob, type: :job do
+describe SendComplaintJob, type: :job do
   describe '#perform_later' do
-    it 'queues a job' do
-      ActiveJob::Base.queue_adapter = :test
+    it 'queues a jobs' do
       expect do
         described_class.perform_later
       end.to have_enqueued_job.on_queue('send_complaints').exactly(:once)
+    end
+  end
+
+  describe '#perform' do
+    subject(:jobs) { described_class.new }
+
+    let(:create_token) { instance_spy(Usecase::Optics::GenerateJwtToken) }
+    let(:get_bearer_token) { instance_spy(Usecase::Optics::GetBearerToken) }
+    let(:create_case) { instance_spy(Usecase::Optics::CreateCase) }
+    let(:gateway) { instance_spy(Gateway::Optics) }
+    let(:input) { { 'submissionAnswers': {} } }
+
+    before do
+      allow(Presenter::Complaint).to receive(:new).and_return(gateway).with(form_builder_payload: input)
+      allow(Usecase::Optics::GenerateJwtToken).to receive(:new).and_return(create_token).with(
+        url: 'https://uat.icasework.com/token?db=hmcts',
+        api_key: Rails.configuration.x.optics.api_key,
+        hmac_secret: Rails.configuration.x.optics.secret_key
+      )
+      allow(Usecase::Optics::GetBearerToken).to receive(:new).and_return(get_bearer_token).with(
+        optics_gateway: be_an_instance_of(Gateway::Optics),
+        generate_jwt_token: create_token
+      )
+      allow(Usecase::Optics::CreateCase).to receive(:new).and_return(create_case).with(
+        optics_gateway: be_an_instance_of(Gateway::Optics),
+        presenter: gateway,
+        get_bearer_token: get_bearer_token
+      )
+    end
+
+    it 'calls the create case usecase' do
+      jobs.perform(form_builder_payload: input)
+      expect(create_case).to have_received(:execute)
     end
   end
 end

--- a/spec/requests/complaint_spec.rb
+++ b/spec/requests/complaint_spec.rb
@@ -1,4 +1,6 @@
 describe 'Submitting a complaint', type: :request do
+  include ActiveJob::TestHelper
+
   before do
     Timecop.freeze(Time.parse('2019-09-11 15:34:46 +0000'))
 
@@ -16,8 +18,9 @@ describe 'Submitting a complaint', type: :request do
         body: 'stub case id response',
         headers: {}
       )
-
-    post '/v1/complaint', params: encrypted_body(msg: runner_submission)
+    perform_enqueued_jobs do
+      post '/v1/complaint', params: encrypted_body(msg: runner_submission)
+    end
   end
 
   let(:expected_optics_payload) do

--- a/spec/usecase/optics/create_case_spec.rb
+++ b/spec/usecase/optics/create_case_spec.rb
@@ -32,8 +32,8 @@ describe Usecase::Optics::CreateCase do
       expect(get_bearer_token).to have_received(:execute)
     end
 
-    xit 'calls present on the presenter' do
-      expect(presenter).to have_received(:present)
+    it 'calls present on the presenter' do
+      expect(presenter).to have_received(:optics_payload)
     end
   end
 end


### PR DESCRIPTION
1. extract ComplaintController logic to delayed job


2. use AsyncAdapter for delayed job in production
(until there is a dedicated worker service infra setup this is the only option "Since jobs share a single thread pool, long-running jobs will block short-lived jobs. Fine for dev/test; bad for production.")
