### PR TITLE
Deployment manifest and Circle deploy scripts for background workers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
             - "7e:e7:44:be:a1:4b:4e:3c:56:65:3a:94:19:50:02:cc"
       - run:
           name: deploy to staging
-          command: './deploy/scripts/circle_deploy.sh "APP_${CIRCLE_SHA1}" staging $KUBE_TOKEN_STAGING'
+          command: './deploy/scripts/circle_deploy.sh $CIRCLE_SHA1 staging $KUBE_TOKEN_STAGING'
 
   deploy_production:
     working_directory: ~/circle/git/hmcts-complaints-formbuilder-adapter
@@ -42,7 +42,7 @@ jobs:
             - "7e:e7:44:be:a1:4b:4e:3c:56:65:3a:94:19:50:02:cc"
       - run:
           name: deploy to production
-          command: './deploy/scripts/circle_deploy.sh "APP_${CIRCLE_SHA1}" production $KUBE_TOKEN_PRODUCTION'
+          command: './deploy/scripts/circle_deploy.sh $CIRCLE_SHA1 production $KUBE_TOKEN_PRODUCTION'
 
 workflows:
   version: 2

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby File.read('.ruby-version').strip
 
+gem 'daemons', '~> 1.3'
 gem 'delayed_job_active_record', '~> 4.1'
 gem 'httparty', '~> 0.17.0'
 gem 'jwe', '~> 0.4.0'
@@ -11,7 +12,6 @@ gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 4.1'
 gem 'rails', '~> 6.0.0'
 gem 'sentry-raven', '~> 2.11'
-gem 'daemons', '~> 1.3'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 4.1'
 gem 'rails', '~> 6.0.0'
 gem 'sentry-raven', '~> 2.11'
+gem 'daemons', '~> 1.3'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
+    daemons (1.3.1)
     delayed_job (4.1.8)
       activesupport (>= 3.0, < 6.1)
     delayed_job_active_record (4.1.4)
@@ -213,6 +214,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  daemons (~> 1.3)
   delayed_job_active_record (~> 4.1)
   httparty (~> 0.17.0)
   jwe (~> 0.4.0)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,13 +46,13 @@ Rails.application.configure do
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
-  # config.active_job.queue_adapter = :delayed_job
+  config.active_job.queue_adapter = :delayed_job
 
-  config.active_job.queue_adapter = ActiveJob::QueueAdapters::AsyncAdapter.new(
-    min_threads: 1,
-    max_threads: 2 * Concurrent.processor_count,
-    idletime: 600.seconds
-  )
+  # config.active_job.queue_adapter = ActiveJob::QueueAdapters::AsyncAdapter.new(
+  #   min_threads: 1,
+  #   max_threads: 2 * Concurrent.processor_count,
+  #   idletime: 600.seconds
+  # )
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,12 +48,6 @@ Rails.application.configure do
 
   config.active_job.queue_adapter = :delayed_job
 
-  # config.active_job.queue_adapter = ActiveJob::QueueAdapters::AsyncAdapter.new(
-  #   min_threads: 1,
-  #   max_threads: 2 * Concurrent.processor_count,
-  #   idletime: 600.seconds
-  # )
-
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true

--- a/deploy/scripts/circle_deploy.sh
+++ b/deploy/scripts/circle_deploy.sh
@@ -4,7 +4,7 @@ set -e -u -o pipefail
 
 CONFIG_FILE="/tmp/helm_deploy.yaml"
 
-image_tag=$1
+git_sha_tag=$1
 environment_name=$2
 kube_token=$3
 
@@ -22,7 +22,8 @@ deploy_with_secrets() {
     kubectl config use-context "circleci_${environment_name}"
 
     helm template deploy/ \
-         --set imagetag=$image_tag \
+         --set app_image_tag="APP_${git_sha_tag}" \
+         --set worker_image_tag="WORKER_${git_sha_tag}" \
          --set environmentName=$environment_name \
          > $CONFIG_FILE
 

--- a/deploy/templates/deployment.yaml
+++ b/deploy/templates/deployment.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: hmcts-complaints-formbuilder-adapter
-        image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/form-builder/hmcts-complaints-formbuilder-adapter:{{ .Values.imagetag }}
+        image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/form-builder/hmcts-complaints-formbuilder-adapter:{{ .Values.app_image_tag }}
         imagePullPolicy: Always
         ports:
         - containerPort: 3000
@@ -22,6 +22,56 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 5
           successThreshold: 1
+        env:
+        - name: RAILS_LOG_TO_STDOUT
+          value: "true"
+        - name: SECRET_KEY_BASE
+          valueFrom:
+            secretKeyRef:
+              name: hmcts-complaints-formbuilder-adapter-secret
+              key: SECRET_KEY_BASE
+        - name: JWE_SHARED_KEY
+          valueFrom:
+            secretKeyRef:
+              name: hmcts-complaints-formbuilder-adapter-secret
+              key: JWE_SHARED_KEY
+        - name: OPTICS_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: hmcts-complaints-formbuilder-adapter-secret
+              key: OPTICS_SECRET_KEY
+        - name: OPTICS_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: hmcts-complaints-formbuilder-adapter-secret
+              key: OPTICS_API_KEY
+        - name: SENTRY_DSN
+          valueFrom:
+            secretKeyRef:
+              name: hmcts-complaints-formbuilder-adapter-secret
+              key: SENTRY_DSN
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: rds-instance-hmcts-complaints-adapter-{{ .Values.environmentName }}
+              key: url
+---
+# workers
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: hmcts-complaints-formbuilder-adapter-worker
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: hmcts-complaints-formbuilder-adapter-worker
+    spec:
+      containers:
+      - name: hmcts-complaints-formbuilder-adapter
+        image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/form-builder/hmcts-complaints-formbuilder-adapter:{{ .Values.worker_image_tag }}
+        imagePullPolicy: Always
         env:
         - name: RAILS_LOG_TO_STDOUT
           value: "true"


### PR DESCRIPTION
This will give us 2 new pods that pull the worker image from ECR.
They should inherit the same secrets as environment variables as the application
pods.