### PR TITLE
endpoint can be overridden with env var

### DIFF
--- a/app/jobs/send_complaint_job.rb
+++ b/app/jobs/send_complaint_job.rb
@@ -27,6 +27,6 @@ class SendComplaintJob < ApplicationJob
   end
 
   def gateway
-    @gateway ||= Gateway::Optics.new(endpoint: Rails.configuration.x.optics.endpoint)
+    Gateway::Optics.new(endpoint: Rails.configuration.x.optics.endpoint)
   end
 end

--- a/app/jobs/send_complaint_job.rb
+++ b/app/jobs/send_complaint_job.rb
@@ -3,7 +3,7 @@ class SendComplaintJob < ApplicationJob
 
   def perform(form_builder_payload:)
     Usecase::Optics::CreateCase.new(
-      optics_gateway: Gateway::Optics.new,
+      optics_gateway: gateway,
       presenter: Presenter::Complaint.new(form_builder_payload: form_builder_payload),
       get_bearer_token: bearer_token
     ).execute
@@ -13,16 +13,20 @@ class SendComplaintJob < ApplicationJob
 
   def bearer_token
     Usecase::Optics::GetBearerToken.new(
-      optics_gateway: Gateway::Optics.new,
+      optics_gateway: gateway,
       generate_jwt_token: generate_token
     )
   end
 
   def generate_token
     Usecase::Optics::GenerateJwtToken.new(
-      url: 'https://uat.icasework.com/token?db=hmcts',
+      endpoint: Rails.configuration.x.optics.endpoint,
       api_key: Rails.configuration.x.optics.api_key,
       hmac_secret: Rails.configuration.x.optics.secret_key
     )
+  end
+
+  def gateway
+    @gateway ||= Gateway::Optics.new(endpoint: Rails.configuration.x.optics.endpoint)
   end
 end

--- a/app/lib/gateway/optics.rb
+++ b/app/lib/gateway/optics.rb
@@ -2,8 +2,10 @@ module Gateway
   class Optics
     class ClientError < StandardError; end
 
-    GET_TOKEN_ENDPOINT = 'https://uat.icasework.com/token?db=hmcts'.freeze
-    ENDPOINT = 'https://uat.icasework.com/createcase?db=hmcts'.freeze
+    def initialize(endpoint:)
+      @get_token_url = "#{endpoint}/token?db=hmcts".freeze
+      @post_case_url = "#{endpoint}/createcase?db=hmcts".freeze
+    end
 
     def request_bearer_token(jwt_token:)
       rep = post_jwt(jwt_token)
@@ -12,7 +14,7 @@ module Gateway
     end
 
     def post(body:, bearer_token:)
-      HTTParty.post(ENDPOINT, headers: headers(bearer_token), body: body)
+      HTTParty.post(@post_case_url, headers: headers(bearer_token), body: body)
     end
 
     private
@@ -26,7 +28,7 @@ module Gateway
 
     def post_jwt(jwt_token)
       result = HTTParty.post(
-        GET_TOKEN_ENDPOINT,
+        @get_token_url,
         headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
         body: URI.encode_www_form(
           grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',

--- a/app/lib/usecase/optics/generate_jwt_token.rb
+++ b/app/lib/usecase/optics/generate_jwt_token.rb
@@ -1,8 +1,8 @@
 module Usecase
   module Optics
     class GenerateJwtToken
-      def initialize(url:, api_key:, hmac_secret:)
-        @url = url
+      def initialize(endpoint:, api_key:, hmac_secret:)
+        @endpoint = "#{endpoint}/token?db=hmcts"
         @api_key = api_key
         @hmac_secret = hmac_secret
       end
@@ -16,12 +16,12 @@ module Usecase
       def payload
         {
           iss: api_key,
-          aud: url,
+          aud: endpoint,
           iat: Time.now.to_i
         }
       end
 
-      attr_reader :url, :api_key, :hmac_secret
+      attr_reader :endpoint, :api_key, :hmac_secret
     end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -49,4 +49,5 @@ Rails.application.configure do
 
   config.x.optics.secret_key = ENV.fetch('OPTICS_SECRET_KEY', SecureRandom.hex(8).freeze)
   config.x.optics.api_key = ENV.fetch('OPTICS_API_KEY', SecureRandom.hex(8).freeze)
+  config.x.optics.endpoint = ENV.fetch('OPTICS_ENDPOINT', 'https://uat.icasework.com'.freeze)
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -101,4 +101,5 @@ Rails.application.configure do
   config.shared_key = ENV.fetch('JWE_SHARED_KEY')
   config.x.optics.secret_key = ENV.fetch('OPTICS_SECRET_KEY')
   config.x.optics.api_key = ENV.fetch('OPTICS_API_KEY')
+  config.x.optics.endpoint = ENV.fetch('OPTICS_ENDPOINT', 'https://uat.icasework.com'.freeze)
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,6 +42,8 @@ Rails.application.configure do
   config.x.optics.secret_key =
     ENV.fetch('OPTICS_SECRET_KEY', 'some_secret_optics_api_key'.freeze)
 
+  config.x.optics.endpoint = ENV.fetch('OPTICS_ENDPOINT', 'https://uat.icasework.com'.freeze)
+
   config.x.optics.api_key =
     ENV.fetch('OPTICS_API_KEY', 'some_optics_api_key'.freeze)
 

--- a/spec/gateway/optics_spec.rb
+++ b/spec/gateway/optics_spec.rb
@@ -1,6 +1,7 @@
 describe Gateway::Optics do
-  subject(:gateway) { described_class.new }
+  subject(:gateway) { described_class.new(endpoint: endpoint) }
 
+  let(:endpoint) { 'https://example.com' }
   let(:api_key) { 'foo' }
   let(:secret_key) { 'bar' }
   let(:token) { 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJmb28iLCJhdWQiOiJodHRwczovL3VhdC5pY2FzZXdvcmsuY29tL3Rva2VuIiwiaWF0IjoxNTY4MjE2MDg2LCJleHAiOjE1ODExNzYwODZ9.0VbK6jGM3Ux8sHq3ekkz-g5xkLxFY4c_6CRVEkA1Sh4' }
@@ -8,7 +9,7 @@ describe Gateway::Optics do
 
   describe '#request_bearer_token' do
     before do
-      stub_request(:post, 'https://uat.icasework.com/token?db=hmcts').to_return(status: 200, body: { access_token: bearer_token }.to_json)
+      stub_request(:post, "#{endpoint}/token?db=hmcts").to_return(status: 200, body: { access_token: bearer_token }.to_json)
     end
 
     let(:expected_body) do
@@ -20,7 +21,7 @@ describe Gateway::Optics do
 
     it 'sends a request for a token' do
       gateway.request_bearer_token(jwt_token: token)
-      expect(WebMock).to have_requested(:post, 'https://uat.icasework.com/token?db=hmcts').with(
+      expect(WebMock).to have_requested(:post, "#{endpoint}/token?db=hmcts").with(
         headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
         body: expected_body
       ).once
@@ -32,7 +33,7 @@ describe Gateway::Optics do
 
     context 'when there is a failing status code returned' do
       before do
-        stub_request(:post, 'https://uat.icasework.com/token?db=hmcts').to_return(status: 401, body: '<error>errors are returned in xml</error>')
+        stub_request(:post, "#{endpoint}/token?db=hmcts").to_return(status: 401, body: '<error>errors are returned in xml</error>')
       end
 
       it 'checks the return code of the request' do
@@ -45,7 +46,7 @@ describe Gateway::Optics do
 
   describe '#post' do
     before do
-      stub_request(:post, 'https://uat.icasework.com/createcase?db=hmcts').to_return(
+      stub_request(:post, "#{endpoint}/createcase?db=hmcts").to_return(
         status: 200, body: {}.to_json
       )
       Timecop.freeze(Time.parse('2019-09-11 15:34:46 +0000'))
@@ -64,7 +65,7 @@ describe Gateway::Optics do
 
     it 'posts given body to optics' do
       gateway.post(body: {}, bearer_token: bearer_token)
-      expect(WebMock).to have_requested(:post, 'https://uat.icasework.com/createcase?db=hmcts').with(
+      expect(WebMock).to have_requested(:post, "#{endpoint}/createcase?db=hmcts").with(
         headers: expected_headers,
         body: {}
       ).once

--- a/spec/jobs/send_complaint_job_spec.rb
+++ b/spec/jobs/send_complaint_job_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe SendComplaintJob, type: :job do
   describe '#perform_later' do
-    it 'queues a jobs' do
+    it 'queues a job' do
       expect do
         described_class.perform_later
       end.to have_enqueued_job.on_queue('send_complaints').exactly(:once)
@@ -21,7 +21,7 @@ describe SendComplaintJob, type: :job do
     before do
       allow(Presenter::Complaint).to receive(:new).and_return(gateway).with(form_builder_payload: input)
       allow(Usecase::Optics::GenerateJwtToken).to receive(:new).and_return(create_token).with(
-        url: 'https://uat.icasework.com/token?db=hmcts',
+        endpoint: Rails.configuration.x.optics.endpoint,
         api_key: Rails.configuration.x.optics.api_key,
         hmac_secret: Rails.configuration.x.optics.secret_key
       )

--- a/spec/usecase/optics/generate_jwt_token_spec.rb
+++ b/spec/usecase/optics/generate_jwt_token_spec.rb
@@ -1,15 +1,15 @@
 describe Usecase::Optics::GenerateJwtToken do
   describe '#generate' do
-    subject(:token) { described_class.new(url: url, api_key: api_key, hmac_secret: secret_key) }
+    subject(:token) { described_class.new(endpoint: url, api_key: api_key, hmac_secret: secret_key) }
 
-    let(:jwt_token) { 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJmb28iLCJhdWQiOiJleGFtcGxlLmNvbSIsImlhdCI6MTU2ODIxNjA4Nn0.oBZf0cFbUrazmp9YRJ5IFzq3hZdCCkJGGRrFCPu6WNQ' }
+    let(:jwt_token) { 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJmb28iLCJhdWQiOiJleGFtcGxlLmNvbS90b2tlbj9kYj1obWN0cyIsImlhdCI6MTU2ODIxNjA4Nn0.YP715rFtiq6BF09VVZCYtog7dvdryZ8nfiQBclMmp2M' }
     let(:url) { 'example.com' }
     let(:api_key) { 'foo' }
     let(:secret_key) { 'bar' }
 
     let(:expected_payload) do
       [
-        { 'aud' => url,
+        { 'aud' => "#{url}/token?db=hmcts",
           'iat' => 1_568_216_086,
           'iss' => 'foo' },
         { 'alg' => 'HS256' }


### PR DESCRIPTION
- removes hardcoded URLs from the gateway

- allow env var OPTICS_ENDPOINT to overrite endpoint
- if OPTICS_ENDPOINT is not provieded default to the uat enviroment