### PR TITLE
add appGroup label

### DIFF
--- a/deploy/templates/deployment.yaml
+++ b/deploy/templates/deployment.yaml
@@ -8,6 +8,7 @@ spec:
     metadata:
       labels:
         app: hmcts-complaints-formbuilder-adapter
+        appGroup: hmcts-complaints-formbuilder-adapter
     spec:
       containers:
       - name: hmcts-complaints-formbuilder-adapter
@@ -67,6 +68,7 @@ spec:
     metadata:
       labels:
         app: hmcts-complaints-formbuilder-adapter-worker
+        appGroup: hmcts-complaints-formbuilder-adapter
     spec:
       containers:
       - name: hmcts-complaints-formbuilder-adapter


### PR DESCRIPTION
So that combined output of workers and app can be tailed easly
i.e 
```bash
kubectl -n <namespace> logs -f -l appGroup=hmcts-complaints-formbuilder-adapter
```
