### PR TITLE
Ensure user data is not logged in stack traces in Sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,4 +1,7 @@
+require_relative '../../lib/sentry_job_argument_scrubber'
+
 Raven.configure do |config|
   config.dsn = ENV.fetch('SENTRY_DSN')
   config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+  config.processors += [SentryJobArgumentScrubber]
 end

--- a/lib/sentry_job_argument_scrubber.rb
+++ b/lib/sentry_job_argument_scrubber.rb
@@ -1,0 +1,9 @@
+class SentryJobArgumentScrubber < Raven::Processor
+  def process(data)
+    return data unless data[:extra][:delayed_job]
+
+    data[:extra][:delayed_job] = STRING_MASK
+    data[:extra][:active_job] = STRING_MASK
+    data
+  end
+end

--- a/spec/sentry_job_argument_scrubber_spec.rb
+++ b/spec/sentry_job_argument_scrubber_spec.rb
@@ -1,0 +1,25 @@
+require 'raven'
+require_relative '../lib/sentry_job_argument_scrubber'
+
+describe SentryJobArgumentScrubber do
+  let(:job_data) do
+    {
+      extra: {
+        delayed_job: ['something sensitive'],
+        active_job: ['something sensitive too']
+      }
+    }
+  end
+
+  it 'masks job arguments' do
+    expect(described_class.new.process(job_data)).to eq(
+      extra: { active_job: '********', delayed_job: '********' }
+    )
+  end
+
+  it 'returns the original data for non job errors' do
+    data = { extra: { foo: ['bar'] } }
+
+    expect(described_class.new.process(data)).to eq(extra: { foo: ['bar'] })
+  end
+end


### PR DESCRIPTION
Sentry allows custom masking of arguments.
This class will ensure that the details of the jobs are not logged.
The error itself can be diagnosed by looking at the .last_error on the job itself.