### PR TITLE
Fix uid not being used for local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ ARG UID
 
 RUN apk add build-base postgresql-contrib postgresql-dev bash tzdata
 
-RUN addgroup -g 1001 -S appgroup && \
-  adduser -u 1001 -S appuser -G appgroup
+RUN addgroup -g ${UID} -S appgroup && \
+  adduser -u ${UID} -S appuser -G appgroup
 
 WORKDIR /app
 ENV HOME /app
@@ -17,9 +17,9 @@ RUN bundle install --no-cache
 
 COPY . .
 
-RUN chown -R 1001:appgroup /app
+RUN chown -R ${UID}:appgroup /app
 
-USER 1001
+USER UID
 
 ENV APP_PORT 3000
 EXPOSE $APP_PORT


### PR DESCRIPTION
- This was in place before but was overwritten in a merge
- This stops dev machines getting file permissions errors when mounting files
- it defaults back 1001 in production like before