### PR TITLE
disable logging all args in workers

### DIFF
--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,9 +1,13 @@
 Delayed::Job.logger = Rails.logger
 
+# rubocop:disable Style/ClassAndModuleChildren
 ActiveSupport.on_load :active_job do
   class ActiveJob::Logging::LogSubscriber
-    private def args_info(job)
+    private
+
+    def args_info(_job)
       ' ### args hidden ###'
     end
   end
 end
+# rubocop:enable Style/ClassAndModuleChildren

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,1 +1,9 @@
 Delayed::Job.logger = Rails.logger
+
+ActiveSupport.on_load :active_job do
+  class ActiveJob::Logging::LogSubscriber
+    private def args_info(job)
+      ' ### args hidden ###'
+    end
+  end
+end


### PR DESCRIPTION
so sensitive data is not logged

what is looks like 

```
[ActiveJob] [SendComplaintJob] [e814aa7e-2d98-4b8e-a705-527f489ddd90] Performing SendComplaintJob (Job ID: e814aa7e-2d98-4b8e-a705-527f489ddd90) from Async(send_complaints) enqueued at 2019-09-25T15:59:36Z### args hidden ###
```