### PR TITLE
Disable logging in workers

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :warn
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,13 +1,2 @@
-Delayed::Job.logger = Rails.logger
-
-# rubocop:disable Style/ClassAndModuleChildren
-ActiveSupport.on_load :active_job do
-  class ActiveJob::Logging::LogSubscriber
-    private
-
-    def args_info(_job)
-      ' ### args hidden ###'
-    end
-  end
-end
-# rubocop:enable Style/ClassAndModuleChildren
+# disable error logging to keep secrets out of the logs
+Delayed::Backend::ActiveRecord::Job.logger.level = :fatal


### PR DESCRIPTION
the monkey patch to stop args being logged in error messages is not loaded in the workers after a lot of trying i have disabled worker logging. (errors in the jobs should still be picked up by sentry anyway)