### PR TITLE
Record a successful submission

### DIFF
--- a/app/jobs/send_complaint_job.rb
+++ b/app/jobs/send_complaint_job.rb
@@ -12,6 +12,8 @@ class SendComplaintJob < ApplicationJob
                                           attachments: attachments),
       get_bearer_token: bearer_token
     ).execute
+
+    record_successful_submission
   end
 
   private
@@ -33,5 +35,9 @@ class SendComplaintJob < ApplicationJob
 
   def gateway
     Gateway::Optics.new(endpoint: Rails.configuration.x.optics.endpoint)
+  end
+
+  def record_successful_submission
+    ProcessedSubmission.create
   end
 end

--- a/app/models/processed_submission.rb
+++ b/app/models/processed_submission.rb
@@ -1,0 +1,2 @@
+class ProcessedSubmission < ApplicationRecord
+end

--- a/db/migrate/20190930114832_create_processed_submissions.rb
+++ b/db/migrate/20190930114832_create_processed_submissions.rb
@@ -1,0 +1,5 @@
+class CreateProcessedSubmissions < ActiveRecord::Migration[6.0]
+  def up
+    create_table :processed_submissions, &:timestamps
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_25_105135) do
+ActiveRecord::Schema.define(version: 2019_09_30_114832) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,6 +40,11 @@ ActiveRecord::Schema.define(version: 2019_09_25_105135) do
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
+  end
+
+  create_table "processed_submissions", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
 end

--- a/spec/jobs/send_complaint_job_spec.rb
+++ b/spec/jobs/send_complaint_job_spec.rb
@@ -55,9 +55,11 @@ describe SendComplaintJob, type: :job do
       expect(spawn_attachments).to have_received(:call).once
     end
 
-    it 'calls the create case usecase' do
-      jobs.perform(form_builder_payload: input)
-      expect(create_case).to have_received(:execute).once
+    context 'when the a submission was submitted to Optics' do
+      it 'creates a new entry' do
+        jobs.perform(form_builder_payload: input)
+        expect(ProcessedSubmission.count).to eq(1)
+      end
     end
   end
 end

--- a/spec/models/processed_submission_spec.rb
+++ b/spec/models/processed_submission_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe ProcessedSubmission do
+  context 'when there are no processed submissions' do
+    it 'returns 0' do
+      expect(described_class.count).to eq(0)
+    end
+  end
+end

--- a/spec/requests/complaint_spec.rb
+++ b/spec/requests/complaint_spec.rb
@@ -100,5 +100,9 @@ describe 'Submitting a complaint', type: :request do
         body: expected_optics_payload
       ).once
     end
+
+    it 'records that there was a successful submission' do
+      expect(ProcessedSubmission.count).to eq(1)
+    end
   end
 end


### PR DESCRIPTION
Delayed::Job doesn't have this metric out of the box since jobs are not soft
deleted. We want to keep track of this metric to ensure the form is working well.

A future PR will expose this data on a /metrics endpoint which can be viewed
manually or piped into a dashboard like Grafana.