### PR TITLE
Expose Delayed::Job metrics

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
   - bin/**
   - db/schema.rb
   - Guardfile
+  - config/environments/**
 
 Style/Documentation:
   Enabled: false

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -1,0 +1,15 @@
+class MetricsController < ActionController::Base
+  http_basic_authenticate_with(
+    name: Rails.configuration.x.metrics.username,
+    password: Rails.configuration.x.metrics.password
+  )
+
+  def show
+    @successful_job_stats = ProcessedSubmission.count
+    @pending_job_stats = Delayed::Job.where('attempts = 0').count
+    @failed_job_stats = Delayed::Job.where('attempts > 0').count
+
+    response.set_header('Content-Type', 'text/plain; version=0.0.4')
+    render 'metrics/show.text'
+  end
+end

--- a/app/views/metrics/show.text.erb
+++ b/app/views/metrics/show.text.erb
@@ -1,0 +1,11 @@
+# TYPE delayed_jobs_successful gauge
+# HELP delayed_jobs_successful Number of successful jobs
+delayed_jobs_successful <%= @successful_job_stats %>
+
+# TYPE delayed_jobs_pending gauge
+# HELP delayed_jobs_pending Number of pending jobs
+delayed_jobs_pending <%= @pending_job_stats %>
+
+# TYPE delayed_jobs_failed gauge
+# HELP delayed_jobs_failed Number of jobs failed
+delayed_jobs_failed <%= @failed_job_stats %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,15 +1,6 @@
 Rails.application.configure do
-  # Settings specified here will take precedence over those in config/application.rb.
-
-  # In the development environment your application's code is reloaded on
-  # every request. This slows down response time but is perfect for development
-  # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
-
-  # Do not eager load code on boot.
   config.eager_load = false
-
-  # Show full error reports.
   config.consider_all_requests_local = true
 
   # Enable/disable caching. By default caching is disabled.
@@ -46,8 +37,9 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.shared_key = ENV.fetch('DEVELOPMENT_JWE_SHARED_KEY', '5d6dc7fc083ea4f0'.freeze)
-
   config.x.optics.secret_key = ENV.fetch('OPTICS_SECRET_KEY', SecureRandom.hex(8).freeze)
   config.x.optics.api_key = ENV.fetch('OPTICS_API_KEY', SecureRandom.hex(8).freeze)
   config.x.optics.endpoint = ENV.fetch('OPTICS_ENDPOINT', 'https://uat.icasework.com'.freeze)
+  config.x.metrics.password = ENV.fetch('METRICS_AUTH_PASSWORD', 'dhh')
+  config.x.metrics.username = ENV.fetch('METRICS_AUTH_USERNAME', 'secret')
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,6 +96,8 @@ Rails.application.configure do
   config.x.optics.secret_key = ENV.fetch('OPTICS_SECRET_KEY')
   config.x.optics.api_key = ENV.fetch('OPTICS_API_KEY')
   config.x.optics.endpoint = ENV.fetch('OPTICS_ENDPOINT', 'https://uat.icasework.com'.freeze)
+  config.x.metrics.password = ENV.fetch('METRICS_AUTH_PASSWORD')
+  config.x.metrics.username = ENV.fetch('METRICS_AUTH_USERNAME')
 end
 
 Rails.application.routes.default_url_options ||= {}

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -47,6 +47,8 @@ Rails.application.configure do
   config.x.optics.api_key =
     ENV.fetch('OPTICS_API_KEY', 'some_optics_api_key'.freeze)
 
+  config.x.metrics.username = 'dhh'
+  config.x.metrics.password = 'secret'
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,5 @@ Rails.application.routes.draw do
   end
 
   get '/health', to: 'health#show'
+  resource :metrics, only: [:show]
 end

--- a/deploy/templates/deployment.yaml
+++ b/deploy/templates/deployment.yaml
@@ -63,6 +63,16 @@ spec:
             secretKeyRef:
               name: rds-instance-hmcts-complaints-adapter-{{ .Values.environmentName }}
               key: url
+        - name: METRICS_AUTH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: rds-instance-hmcts-complaints-adapter-{{ .Values.environmentName }}
+              key: METRICS_AUTH_PASSWORD
+        - name: METRICS_AUTH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: rds-instance-hmcts-complaints-adapter-{{ .Values.environmentName }}
+              key: METRICS_AUTH_USERNAME
 ---
 # workers
 apiVersion: extensions/v1beta1
@@ -121,3 +131,13 @@ spec:
             secretKeyRef:
               name: rds-instance-hmcts-complaints-adapter-{{ .Values.environmentName }}
               key: url
+        - name: METRICS_AUTH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: rds-instance-hmcts-complaints-adapter-{{ .Values.environmentName }}
+              key: METRICS_AUTH_PASSWORD
+        - name: METRICS_AUTH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: rds-instance-hmcts-complaints-adapter-{{ .Values.environmentName }}
+              key: METRICS_AUTH_USERNAME

--- a/spec/requests/metrics_spec.rb
+++ b/spec/requests/metrics_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+describe 'Delayed Job Metrics', type: :request do
+  before do
+    ENV['METRICS_AUTH_USERNAME'] = 'dhh'
+    ENV['METRICS_AUTH_PASSWORD'] = 'secret'
+  end
+
+  context 'when unauthenticated' do
+    before do
+      get '/metrics'
+    end
+
+    it 'denies access' do
+      expect(response.body).to eq("HTTP Basic: Access denied.\n")
+    end
+  end
+
+  context 'when authenticated' do
+    let(:auth_headers) do
+      {
+        'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials('dhh', 'secret')
+      }
+    end
+
+    let(:job) { Delayed::Job.create!(handler: '{}') }
+
+    context 'when there are successful jobs' do
+      before do
+        ProcessedSubmission.create!
+        get '/metrics', headers: auth_headers
+      end
+
+      it 'shows pending jobs' do
+        expected_result = '# TYPE delayed_jobs_successful gauge
+# HELP delayed_jobs_successful Number of successful jobs
+delayed_jobs_successful 1'
+        expect(response.body).to include(expected_result)
+      end
+    end
+
+    context 'when there are pending jobs' do
+      before do
+        job.update(attempts: 0)
+        get '/metrics', headers: auth_headers
+      end
+
+      it 'shows pending jobs' do
+        expected_result = '# TYPE delayed_jobs_pending gauge
+# HELP delayed_jobs_pending Number of pending jobs
+delayed_jobs_pending 1'
+        expect(response.body).to include(expected_result)
+      end
+    end
+
+    context 'when there are failed jobs' do
+      before do
+        job.update(attempts: 1)
+        get '/metrics', headers: auth_headers
+      end
+
+      it 'shows failed jobs' do
+        expected_result = '# TYPE delayed_jobs_failed gauge
+# HELP delayed_jobs_failed Number of jobs failed
+delayed_jobs_failed 1'
+
+        expect(response.body).to include(expected_result)
+      end
+    end
+
+    describe 'Response headers' do
+      before { get '/metrics', headers: auth_headers }
+
+      it 'adds the prometheus version' do
+        expect(response.headers['Content-Type']).to eq('text/plain; version=0.0.4')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is currently used to see how many submissions have been submitted to
Optics.

The format of this output allows us to easily feed this into Grafana in the
future.