### PR TITLE
Increase key_space_limit for POST requests

### DIFF
--- a/config/initializers/rack.rb
+++ b/config/initializers/rack.rb
@@ -1,0 +1,1 @@
+Rack::Utils.key_space_limit = 262_144


### PR DESCRIPTION
We have a complaint 35345 characters, which was rejected by Rails'
default limit.

Temporarily increase this as we figure out what this limit should be.
https://github.com/rack/rack/issues/318