### PR TITLE
Replace image from docker hub with aws ecr in test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 version: 2.1
 orbs:
-  aws-ecr: circleci/aws-ecr@6.3.0
+  aws-ecr: circleci/aws-ecr@6.7.0
 
 jobs:
   test:
     working_directory: ~/circle
     docker:
-      - image: asmega/fb-builder:latest
+      - image: circleci/buildpack-deps:14.04
     steps:
       - checkout
       - setup_remote_docker
@@ -18,8 +18,11 @@ jobs:
           command: docker-compose run --rm app bundle exec rspec
   deploy_staging:
     working_directory: ~/circle/git/hmcts-complaints-formbuilder-adapter
-    docker:
-      - image: asmega/fb-builder:latest
+    docker: &ecr_base_image
+      - image: $AWS_BUILD_IMAGE_ECR_ACCOUNT_URL
+        aws_auth:
+          aws_access_key_id: $AWS_BUILD_IMAGE_ACCESS_KEY_ID
+          aws_secret_access_key: $AWS_BUILD_IMAGE_SECRET_ACCESS_KEY
     steps:
       - checkout
       - setup_remote_docker
@@ -32,8 +35,7 @@ jobs:
 
   deploy_production:
     working_directory: ~/circle/git/hmcts-complaints-formbuilder-adapter
-    docker:
-      - image: asmega/fb-builder:latest
+    docker: *ecr_base_image
     steps:
       - checkout
       - setup_remote_docker
@@ -58,7 +60,9 @@ workflows:
           tag: "APP_${CIRCLE_SHA1}"
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - deploy-to-staging
       - aws-ecr/build-and-push-image:
           name: push_worker_image
           dockerfile: Dockerfile.worker
@@ -68,7 +72,9 @@ workflows:
           tag: "WORKER_${CIRCLE_SHA1}"
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - deploy-to-staging
       - deploy_staging:
           requires:
             - push_app_image
@@ -76,7 +82,9 @@ workflows:
             - test
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - deploy-to-staging
       - confirm_production_deploy:
           type: approval
           requires:


### PR DESCRIPTION
[Trello](https://trello.com/b/YIJbuKyu/form-builder-2020)

## Description

Replace image from docker hub with aws ecr in test.

## Caveats

There are already env vars on CircleCI named "AWS_ECR_ACCOUNT_URL", "AWS_ACCESS_KEY_ID" and "AWS_SECRET_ACCESS_KEY" which is regards to where the image hmcts-complaints-formbuilder-adapter will be pushed so I have to named the build image with the prefix "BUILD_IMAGE" to it.