### PR TITLE
Add secrets to deployments

### DIFF
--- a/deploy/hmcts-complaints-formbuilder-adapter-chart/templates/db_sweeper.yaml
+++ b/deploy/hmcts-complaints-formbuilder-adapter-chart/templates/db_sweeper.yaml
@@ -28,43 +28,43 @@ spec:
               - name: OPTICS_ENDPOINT
                 valueFrom:
                   secretKeyRef:
-                    name: hmcts-complaints-formbuilder-adapter-secret
-                    key: OPTICS_ENDPOINT
+                    name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
+                    key: optics_endpoint
               - name: SECRET_KEY_BASE
                 valueFrom:
                   secretKeyRef:
-                    name: hmcts-complaints-formbuilder-adapter-secret
-                    key: SECRET_KEY_BASE
+                    name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
+                    key: secret_key_base
               - name: JWE_SHARED_KEY
                 valueFrom:
                   secretKeyRef:
-                    name: hmcts-complaints-formbuilder-adapter-secret
-                    key: JWE_SHARED_KEY
+                    name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
+                    key: jwe_shared_key
               - name: OPTICS_SECRET_KEY
                 valueFrom:
                   secretKeyRef:
-                    name: hmcts-complaints-formbuilder-adapter-secret
-                    key: OPTICS_SECRET_KEY
+                    name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
+                    key: optics_secret_key
               - name: OPTICS_API_KEY
                 valueFrom:
                   secretKeyRef:
-                    name: hmcts-complaints-formbuilder-adapter-secret
-                    key: OPTICS_API_KEY
+                    name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
+                    key: optics_api_key
               - name: SENTRY_DSN
                 valueFrom:
                   secretKeyRef:
-                    name: hmcts-complaints-formbuilder-adapter-secret
-                    key: SENTRY_DSN
+                    name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
+                    key: sentry_dsn
               - name: METRICS_AUTH_PASSWORD
                 valueFrom:
                   secretKeyRef:
-                    name: hmcts-complaints-formbuilder-adapter-secret
-                    key: METRICS_AUTH_PASSWORD
+                    name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
+                    key: metrics_auth_password
               - name: METRICS_AUTH_USERNAME
                 valueFrom:
                   secretKeyRef:
-                    name: hmcts-complaints-formbuilder-adapter-secret
-                    key: METRICS_AUTH_USERNAME
+                    name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
+                    key: metrics_auth_username
               - name: DATABASE_URL
                 valueFrom:
                   secretKeyRef:

--- a/deploy/hmcts-complaints-formbuilder-adapter-chart/templates/deployment.yaml
+++ b/deploy/hmcts-complaints-formbuilder-adapter-chart/templates/deployment.yaml
@@ -34,33 +34,33 @@ spec:
         - name: OPTICS_ENDPOINT
           valueFrom:
             secretKeyRef:
-              name: hmcts-complaints-formbuilder-adapter-secret
-              key: OPTICS_ENDPOINT
+              name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
+              key: optics_endpoint
         - name: SECRET_KEY_BASE
           valueFrom:
             secretKeyRef:
-              name: hmcts-complaints-formbuilder-adapter-secret
-              key: SECRET_KEY_BASE
+              name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
+              key: secret_key_base
         - name: JWE_SHARED_KEY
           valueFrom:
             secretKeyRef:
-              name: hmcts-complaints-formbuilder-adapter-secret
-              key: JWE_SHARED_KEY
+              name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
+              key: jwe_shared_key
         - name: OPTICS_SECRET_KEY
           valueFrom:
             secretKeyRef:
-              name: hmcts-complaints-formbuilder-adapter-secret
-              key: OPTICS_SECRET_KEY
+              name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
+              key: optics_secret_key
         - name: OPTICS_API_KEY
           valueFrom:
             secretKeyRef:
-              name: hmcts-complaints-formbuilder-adapter-secret
-              key: OPTICS_API_KEY
+              name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
+              key: optics_api_key
         - name: SENTRY_DSN
           valueFrom:
             secretKeyRef:
-              name: hmcts-complaints-formbuilder-adapter-secret
-              key: SENTRY_DSN
+              name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
+              key: sentry_dsn
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:
@@ -69,13 +69,13 @@ spec:
         - name: METRICS_AUTH_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: hmcts-complaints-formbuilder-adapter-secret
-              key: METRICS_AUTH_PASSWORD
+              name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
+              key: metrics_auth_password
         - name: METRICS_AUTH_USERNAME
           valueFrom:
             secretKeyRef:
-              name: hmcts-complaints-formbuilder-adapter-secret
-              key: METRICS_AUTH_USERNAME
+              name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
+              key: metrics_auth_username
 ---
 # workers
 apiVersion: apps/v1
@@ -105,33 +105,33 @@ spec:
         - name: OPTICS_ENDPOINT
           valueFrom:
             secretKeyRef:
-              name: hmcts-complaints-formbuilder-adapter-secret
-              key: OPTICS_ENDPOINT
+              name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
+              key: optics_endpoint
         - name: SECRET_KEY_BASE
           valueFrom:
             secretKeyRef:
-              name: hmcts-complaints-formbuilder-adapter-secret
-              key: SECRET_KEY_BASE
+              name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
+              key: secret_key_base
         - name: JWE_SHARED_KEY
           valueFrom:
             secretKeyRef:
-              name: hmcts-complaints-formbuilder-adapter-secret
-              key: JWE_SHARED_KEY
+              name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
+              key: jwe_shared_key
         - name: OPTICS_SECRET_KEY
           valueFrom:
             secretKeyRef:
-              name: hmcts-complaints-formbuilder-adapter-secret
-              key: OPTICS_SECRET_KEY
+              name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
+              key: optics_secret_key
         - name: OPTICS_API_KEY
           valueFrom:
             secretKeyRef:
-              name: hmcts-complaints-formbuilder-adapter-secret
-              key: OPTICS_API_KEY
+              name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
+              key: optics_api_key
         - name: SENTRY_DSN
           valueFrom:
             secretKeyRef:
-              name: hmcts-complaints-formbuilder-adapter-secret
-              key: SENTRY_DSN
+              name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
+              key: sentry_dsn
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:
@@ -140,10 +140,10 @@ spec:
         - name: METRICS_AUTH_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: hmcts-complaints-formbuilder-adapter-secret
-              key: METRICS_AUTH_PASSWORD
+              name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
+              key: metrics_auth_password
         - name: METRICS_AUTH_USERNAME
           valueFrom:
             secretKeyRef:
-              name: hmcts-complaints-formbuilder-adapter-secret
-              key: METRICS_AUTH_USERNAME
+              name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
+              key: metrics_auth_username

--- a/deploy/hmcts-complaints-formbuilder-adapter-chart/templates/secrets.yaml
+++ b/deploy/hmcts-complaints-formbuilder-adapter-chart/templates/secrets.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
+type: Opaque
+data:
+  jwe_shared_key: {{ .Values.jwe_shared_key }}
+  metrics_auth_password: {{ .Values.metrics_auth_password }}
+  metrics_auth_username: {{ .Values.metrics_auth_username }}
+  optics_api_key: {{ .Values.optics_api_key }}
+  optics_endpoint: {{ .Values.optics_endpoint }}
+  optics_secret_key: {{ .Values.optics_secret_key }}
+  secret_key_base: {{ .Values.secret_key_base }}
+  sentry_dsn: {{ .Values.sentry_dsn }}


### PR DESCRIPTION
This brings the adapter into line with the other apps on the platform.

Previously the adapter secrets were held as an actual kubernetes secret config file which the pipeline applied.

Now the secrets are mapped to a `secrets.yaml` file in this repo and the fb-deploy scripts will apply them during deployment.

https://trello.com/c/Gyg2uwc0/948-fix-hmcts-adapter-secrets