### PR TITLE
Bump sentry to 3.0.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'jwt', '~> 2.2'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 5.0'
 gem 'rails', '~> 6.0.3'
-gem 'sentry-raven', '~> 3.1'
+gem 'sentry-raven', '3.0.4'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,8 +78,9 @@ GEM
     factory_bot_rails (6.1.0)
       factory_bot (~> 6.1.0)
       railties (>= 5.0.0)
-    faraday (1.0.1)
+    faraday (1.1.0)
       multipart-post (>= 1.2, < 3)
+      ruby2_keywords
     ffi (1.13.1)
     formatador (0.2.5)
     globalid (0.4.2)
@@ -216,7 +217,8 @@ GEM
       rubocop (~> 0.87)
       rubocop-ast (>= 0.7.1)
     ruby-progressbar (1.10.1)
-    sentry-raven (3.1.1)
+    ruby2_keywords (0.0.2)
+    sentry-raven (3.0.4)
       faraday (>= 1.0)
     shellany (0.0.1)
     spring (2.1.1)
@@ -264,7 +266,7 @@ DEPENDENCIES
   rspec-rails
   rubocop (~> 0.93.1)
   rubocop-rspec (~> 1.44)
-  sentry-raven (~> 3.1)
+  sentry-raven (= 3.0.4)
   spring
   spring-watcher-listen (~> 2.0.0)
   timecop (~> 0.9.2)


### PR DESCRIPTION
Downgrading sentry because the last version has a bug using delayed
job. https://github.com/getsentry/sentry-ruby/pull/1057