### PR TITLE
Add list submission ids rake task

### DIFF
--- a/lib/tasks/list_failed_submission_ids.rake
+++ b/lib/tasks/list_failed_submission_ids.rake
@@ -1,0 +1,12 @@
+desc 'Retrieves submission IDs for all Delayed::Jobs in the queue'
+task list_failed_submission_ids: :environment do
+  submission_ids = Delayed::Job.all.map do |job|
+    job.handler.match(/(?<=submissionId: )(.*)(?=\n)/)[0]
+  end
+
+  if submission_ids.empty?
+    puts 'No submission IDs found'
+  else
+    puts submission_ids
+  end
+end


### PR DESCRIPTION
This task will list all failed job submissions ids so we can
go in submitter to find those submission ids in the payload

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>
Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>