### PR TITLE
Set custom Delayed::Job max_attempts

### DIFF
--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,2 +1,3 @@
 # disable error logging to keep secrets out of the logs
 Delayed::Backend::ActiveRecord::Job.logger.level = :fatal
+Delayed::Worker.max_attempts = 5


### PR DESCRIPTION
This stems from a recent incident where the Optics system was unable to retrieve attachments related to a submission. The adapter kept retrying up to the default max_attempts which is 25.

This resulted in 25 cases being created for each submission as the way the Optics system works is to create the case first before then asking the adapter for any attachments related to it.

Here we set the max_attempts to be 5.

Ideally it would be best for Optics to check whether the case already exists based on the submission ID it has received in order to not attempt to create a brand new one each time.

https://trello.com/c/9oGKWZiQ/1130-hmcts-adaptor-queue-max-retries