### PR TITLE
Update Correspondence Type

### DIFF
--- a/app/lib/presenter/correspondence.rb
+++ b/app/lib/presenter/correspondence.rb
@@ -9,7 +9,7 @@ module Presenter
     EXISTING_CLAIM = 'existing-claim'.freeze
     MAIN = 'Main'.freeze
     TEAM = '1022731A'.freeze
-    TYPE = 'Correspondence'.freeze
+    TYPE = '1353909'.freeze
     APPLICANT_TYPE = {
       'claimant' => 'A',
       'defendant' => 'B',


### PR DESCRIPTION
The Type for a Correspondence submission should no longer be
'Correspondence' but rather and identifier that the OPTICS system uses
to identify the case type from the payload it receives.