### PR TITLE
Correspondence Type differs per environment

### DIFF
--- a/app/lib/presenter/correspondence.rb
+++ b/app/lib/presenter/correspondence.rb
@@ -117,9 +117,13 @@ module Presenter
       {
         db: DB,
         Team: TEAM,
-        Type: TYPE,
+        Type: type,
         'Case.ContactMethod': CONTACT_METHOD
       }
+    end
+
+    def type
+      ENV['CORRESPONDENCE_TYPE'] || TYPE
     end
 
     def representing?

--- a/deploy/hmcts-complaints-formbuilder-adapter-chart/templates/deployment.yaml
+++ b/deploy/hmcts-complaints-formbuilder-adapter-chart/templates/deployment.yaml
@@ -76,6 +76,11 @@ spec:
             secretKeyRef:
               name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
               key: metrics_auth_username
+        - name: CORRESPONDENCE_TYPE
+          valueFrom:
+            secretKeyRef:
+              name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
+              key: correspondence_type
 ---
 # workers
 apiVersion: apps/v1
@@ -147,3 +152,8 @@ spec:
             secretKeyRef:
               name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
               key: metrics_auth_username
+        - name: CORRESPONDENCE_TYPE
+          valueFrom:
+            secretKeyRef:
+              name: hmcts-complaints-formbuilder-adapter-secrets-{{ .Values.environmentName }}
+              key: correspondence_type

--- a/deploy/hmcts-complaints-formbuilder-adapter-chart/templates/secrets.yaml
+++ b/deploy/hmcts-complaints-formbuilder-adapter-chart/templates/secrets.yaml
@@ -12,3 +12,4 @@ data:
   optics_secret_key: {{ .Values.optics_secret_key }}
   secret_key_base: {{ .Values.secret_key_base }}
   sentry_dsn: {{ .Values.sentry_dsn }}
+  correspondence_type: {{ .Values.correspondence_type }}

--- a/spec/presenter/correspondence_spec.rb
+++ b/spec/presenter/correspondence_spec.rb
@@ -269,6 +269,31 @@ RSpec.describe Presenter::Correspondence do
       end
     end
 
+    context 'correspondence type' do
+      let(:input_payload) { {} }
+
+      context 'when type is not set in the environment' do
+        it 'defaults to use the type in the model' do
+          expect(presenter.optics_payload[:Type]).to eq(Presenter::Correspondence::TYPE)
+        end
+      end
+
+      context 'when type is set in the environment' do
+        let(:correspondence_type) { 'foo' }
+        let(:constant_data) do
+          constant_data.merge({ Type: correspondence_type })
+        end
+
+        before do
+          allow(ENV).to receive(:[]).with('CORRESPONDENCE_TYPE').and_return(correspondence_type)
+        end
+
+        it 'uses the type from the environment' do
+          expect(presenter.optics_payload[:Type]).to eq(correspondence_type)
+        end
+      end
+    end
+
     context 'representing' do
       let(:today) { Time.now.strftime('%d/%m/%Y') }
       let(:input_payload) do


### PR DESCRIPTION
For the staging environment the Correspondence Type should be
'Correspondence'. For the live environment it needs to be an identifier
that OPTICS understands in order to create the correct case.

Both of these values are set in the
hmcts-complaints-formbuilder-adapter-deploy repository

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>