### PR TITLE
Add ClaimNumber property to OPTICS payload replacing NewOrExistingClaim 

### DIFF
--- a/app/lib/presenter/correspondence.rb
+++ b/app/lib/presenter/correspondence.rb
@@ -6,7 +6,7 @@ module Presenter
     AGENT = 'Agent'.freeze
     CONTACT_METHOD = 'Online form'.freeze
     DB = 'hmcts'.freeze
-    EXISTING_CLAIM = 'existing-claim'.freeze
+    EXISTING_CASE_REFERENCE = 'CaseReferenceYes'.freeze
     MAIN = 'Main'.freeze
     TEAM = '1022731A'.freeze
     TYPE = '1353909'.freeze
@@ -88,11 +88,11 @@ module Presenter
     end
 
     def case_reference_yes_no
-      existing_claim? ? 'Yes' : 'No'
+      existing_case_reference? ? 'Yes' : 'No'
     end
 
     def case_reference
-      existing_claim? ? submission_answers.fetch(:CaseReference, '') : ''
+      existing_case_reference? ? submission_answers.fetch(:CaseReference, '') : ''
     end
 
     def customer_party_context
@@ -134,9 +134,9 @@ module Presenter
       customer_party_context == MAIN
     end
 
-    def existing_claim?
-      @existing_claim ||=
-        submission_answers.fetch(:NewOrExistingClaim, '') == EXISTING_CLAIM
+    def existing_case_reference?
+      @existing_case_reference ||=
+        submission_answers.fetch(:ClaimNumber, '') == EXISTING_CASE_REFERENCE
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/spec/presenter/correspondence_spec.rb
+++ b/spec/presenter/correspondence_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Presenter::Correspondence do
         submissionId: '891c837c-adef-4854-8bd0-d681577f381e',
         submissionAnswers:
         {
+          ClaimNumber: 'CaseReferenceYes',
           NewOrExistingClaim: 'existing-claim',
           CaseReference: 'some reference',
           ApplicantType: 'claimant',
@@ -71,6 +72,7 @@ RSpec.describe Presenter::Correspondence do
         let(:input_payload) do
           {
             NewOrExistingClaim: 'existing-claim',
+            ClaimNumber: 'CaseReferenceYes',
             CaseReference: 'some reference'
           }
         end
@@ -84,6 +86,7 @@ RSpec.describe Presenter::Correspondence do
         let(:input_payload) do
           {
             NewOrExistingClaim: 'new-claim',
+            ClaimNumber: 'CaseReferenceNo',
             CaseReference: 'some reference that should not be there'
           }
         end
@@ -237,6 +240,7 @@ RSpec.describe Presenter::Correspondence do
           Applicant1Email: 'quigon@jedi-temple.com',
           Applicant1Phone: '5555555555',
           NewOrExistingClaim: 'new-claim',
+          ClaimNumber: 'CaseReferenceNo',
           QueryTypeClaimant: 'court-judgement'
         }
       end

--- a/spec/requests/correspondence_spec.rb
+++ b/spec/requests/correspondence_spec.rb
@@ -40,6 +40,7 @@ describe 'Submitting a correspondence', type: :request do
       submissionId: '891c837c-adef-4854-8bd0-d681577f381e',
       submissionAnswers:
       {
+        ClaimNumber: 'CaseReferenceYes',
         NewOrExistingClaim: 'existing-claim',
         CaseReference: 'some reference',
         ApplicantType: 'representing-claimant',
@@ -87,6 +88,7 @@ describe 'Submitting a correspondence', type: :request do
       submissionAnswers:
       {
         NewOrExistingClaim: 'new-claim',
+        ClaimNumber: 'CaseReferenceNo',
         CaseReference: '',
         ApplicantType: 'claimant',
         MessageContent: 'some message body thing',


### PR DESCRIPTION
HMCTS have updated their form pages to add an additional property which
is sent in the Submission payload: `ClaimNumber`.

This has two potential values: `CaseReferenceYes` and `CaseReferenceNo`.

Funcationally wise this replaces the previous logic around
`NewOrExistingClaim` property. This property will still exist in the
payload, as their form will pass it on to the adapter, however it is not
used at all. I have left that in the test payloads because it is still
received, just never mapped.