### PR TITLE
Use Postgres 11 image in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   db:
-    image: postgres
+    image: postgres:11-alpine
     environment:
       POSTGRES_PASSWORD: password
       POSTGRES_USER: postgres


### PR DESCRIPTION
For some reason the main docker image has permission issues with the
entrypoint file.

The adapter DB uses postgres 11 so swap to using the postgres:11-alpine
image in the docker-compose. This is only used for testing.