### PR TITLE
Add ingress annotations to kubernetes configuration

### DIFF
--- a/deploy/hmcts-complaints-formbuilder-adapter-chart/templates/ingress.yaml
+++ b/deploy/hmcts-complaints-formbuilder-adapter-chart/templates/ingress.yaml
@@ -2,6 +2,9 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: hmcts-complaints-formbuilder-adapter-{{ .Values.environmentName }}
+  annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: "hmcts-complaints-formbuilder-adapter-{{ .Values.environmentName }}-hmcts-complaints-formbuilder-adapter-{{ .Values.environmentName }}-blue"
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
These are required for the upcoming EKS migrations.

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>