### PR TITLE
Use circleci convenience images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     working_directory: ~/circle
     docker:
-      - image: circleci/buildpack-deps:14.04
+      - image: cimg/ruby:2.7.5
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
circleci/ images have been depreacted. `buildpack-deps` images do not
have a new convenience image to use therefore we can just use a standard
ruby 2.7.5 image