### PR TITLE
Change order of parameters

### DIFF
--- a/app/lib/presenter/feedback.rb
+++ b/app/lib/presenter/feedback.rb
@@ -23,8 +23,8 @@ module Presenter
         'External.RequestMethod': REQUEST_METHOD,
         PartyContext: PARTY_CONTEXT,
         AssignedTeam: submission_answers.fetch(:contact_location, ''),
-        'Case.Team': submission_answers.fetch(:contact_location, ''),
         'Case.ServiceTeam': COURTS,
+        'Case.Team': submission_answers.fetch(:contact_location, ''),
         Details: submission_answers.fetch(:feedback_details, '')
       }
     end

--- a/spec/requests/feedback_spec.rb
+++ b/spec/requests/feedback_spec.rb
@@ -62,8 +62,8 @@ describe 'Submitting feedback', type: :request do
       'External.RequestMethod': Presenter::Feedback::REQUEST_METHOD,
       PartyContext: Presenter::Feedback::PARTY_CONTEXT,
       AssignedTeam: '1111',
-      'Case.Team': '1111',
       'Case.ServiceTeam': 'COURTS',
+      'Case.Team': '1111',
       Details: 'all of the feedback'
     }.to_json
   end


### PR DESCRIPTION
[Trello](https://trello.com/c/0l5OeCmI/2801-hmcts-complaints-adaptor-change-request)
This has come as a request from HMCTS, they are trying to troubleshoot an issue whereby the 'comments' and 'praise' forms have not been created with the correct location. Civica have suggested changing the order of the parameters.