### PR TITLE
Remove two params from the feedback form

### DIFF
--- a/app/lib/presenter/feedback.rb
+++ b/app/lib/presenter/feedback.rb
@@ -11,9 +11,7 @@ module Presenter
     REQUEST_METHOD = 'Online form'.freeze
     TYPE = 'UF144908'.freeze
     PARTY_CONTEXT = 'Main'.freeze
-    COURTS = 'COURTS'.freeze
 
-    # rubocop:disable Metrics/MethodLength
     def optics_payload
       {
         Type: TYPE,
@@ -23,11 +21,8 @@ module Presenter
         'External.RequestMethod': REQUEST_METHOD,
         PartyContext: PARTY_CONTEXT,
         AssignedTeam: submission_answers.fetch(:contact_location, ''),
-        'Case.ServiceTeam': COURTS,
-        'Case.Team': submission_answers.fetch(:contact_location, ''),
         Details: submission_answers.fetch(:feedback_details, '')
       }
     end
-    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/spec/requests/feedback_spec.rb
+++ b/spec/requests/feedback_spec.rb
@@ -62,8 +62,6 @@ describe 'Submitting feedback', type: :request do
       'External.RequestMethod': Presenter::Feedback::REQUEST_METHOD,
       PartyContext: Presenter::Feedback::PARTY_CONTEXT,
       AssignedTeam: '1111',
-      'Case.ServiceTeam': 'COURTS',
-      'Case.Team': '1111',
       Details: 'all of the feedback'
     }.to_json
   end


### PR DESCRIPTION
[Trello](https://trello.com/c/GSVqiLH2/2847-hmcts-adapter-remove-caseserviceteam-and-caseteam-params-and-add-assignedteamxs)
This was a request from the HMCTS team as they are not seeing the correct params in OPTICS.

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>
Co-authored-by: Hellema Ibrahim <hellema.ibrahim@digital.justice.gov.uk>