### PR TITLE
Refactor Presenters to inherit from BasePresenter

### DIFF
--- a/app/lib/presenter/base_presenter.rb
+++ b/app/lib/presenter/base_presenter.rb
@@ -1,0 +1,20 @@
+module Presenter
+  class BasePresenter
+    def initialize(form_builder_payload:)
+      @form_builder_payload = form_builder_payload
+    end
+
+    private
+
+    attr_reader :form_builder_payload
+
+    def submission_answers
+      @submission_answers ||= form_builder_payload.fetch(:submissionAnswers)
+    end
+
+    def request_date(format = '%Y-%m-%d')
+      time = submission_answers.fetch(:submissionDate, (Time.now.to_i * 1000).to_s)
+      Time.at(time.to_s.to_i / 1000).strftime(format)
+    end
+  end
+end

--- a/app/lib/presenter/comment.rb
+++ b/app/lib/presenter/comment.rb
@@ -1,13 +1,5 @@
 module Presenter
-  class Comment
-    include SubmissionDate
-
-    attr_reader :submission_answers
-
-    def initialize(form_builder_payload:)
-      @submission_answers = form_builder_payload.fetch(:submissionAnswers)
-    end
-
+  class Comment < BasePresenter
     REQUEST_METHOD = 'Online form'.freeze
 
     def optics_payload

--- a/app/lib/presenter/complaint.rb
+++ b/app/lib/presenter/complaint.rb
@@ -1,9 +1,7 @@
 module Presenter
-  class Complaint
-    include SubmissionDate
-
+  class Complaint < BasePresenter
     def initialize(form_builder_payload:, attachments:)
-      @submission_answers = form_builder_payload.fetch(:submissionAnswers)
+      super(form_builder_payload: form_builder_payload)
       @attachments = attachments
     end
 
@@ -20,7 +18,7 @@ module Presenter
 
     private
 
-    attr_reader :submission_answers, :attachments
+    attr_reader :attachments
 
     # rubocop:disable Metrics/MethodLength
     def customer_data

--- a/app/lib/presenter/correspondence.rb
+++ b/app/lib/presenter/correspondence.rb
@@ -1,8 +1,6 @@
 module Presenter
   # rubocop:disable Metrics/ClassLength
-  class Correspondence
-    attr_reader :submission_answers
-
+  class Correspondence < BasePresenter
     AGENT = 'Agent'.freeze
     CONTACT_METHOD = 'Online form'.freeze
     DB = 'hmcts'.freeze
@@ -28,10 +26,6 @@ module Presenter
       'claim-not-paid' => 'G'
     }.freeze
 
-    def initialize(form_builder_payload:)
-      @submission_answers = form_builder_payload.fetch(:submissionAnswers)
-    end
-
     # rubocop:disable Metrics/MethodLength
     def optics_payload
       {
@@ -45,7 +39,7 @@ module Presenter
         'CaseContactPostcode.Subject': submission_answers.fetch(:ClientPostcode, ''),
         'CaseContactCustom17.Representative': submission_answers.fetch(:CompanyName, ''),
         'CaseContactCustom18.Subject': '',
-        'Case.ReceivedDate': submission_date
+        'Case.ReceivedDate': request_date('%d/%m/%Y')
       }.merge(representing_data, self_representing_data, constant_data)
     end
 
@@ -97,11 +91,6 @@ module Presenter
 
     def customer_party_context
       @customer_party_context ||= applicant_type == 'C' ? AGENT : MAIN
-    end
-
-    def submission_date
-      time = submission_answers.fetch(:submissionDate, (Time.now.to_i * 1000).to_s)
-      Time.at(time.to_s.to_i / 1000).strftime('%d/%m/%Y')
     end
 
     def query_type_claimant_or_defendant

--- a/app/lib/presenter/feedback.rb
+++ b/app/lib/presenter/feedback.rb
@@ -1,13 +1,5 @@
 module Presenter
-  class Feedback
-    include SubmissionDate
-
-    attr_reader :submission_answers
-
-    def initialize(form_builder_payload:)
-      @submission_answers = form_builder_payload.fetch(:submissionAnswers)
-    end
-
+  class Feedback < BasePresenter
     REQUEST_METHOD = 'Online form'.freeze
     TYPE = 'UF144908'.freeze
     PARTY_CONTEXT = 'Main'.freeze

--- a/app/lib/presenter/submission_date.rb
+++ b/app/lib/presenter/submission_date.rb
@@ -1,8 +1,0 @@
-module Presenter
-  module SubmissionDate
-    def request_date
-      time = submission_answers.fetch(:submissionDate, (Time.now.to_i * 1000).to_s)
-      Time.at(time.to_s.to_i / 1000).strftime('%Y-%m-%d')
-    end
-  end
-end


### PR DESCRIPTION
Remove the submission date module and add the request_date method to the BasePresenter.

Change the initializer to take the form_builder_payload and use a memoized submission_answers method to cater for all the presenters that require it.