### PR TITLE
Do not attempt to create a case for previously processed submissions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,22 +104,23 @@ workflows:
               only:
                 - master
                 - deploy-to-staging
-      - slack/approval-notification:
-          message: ":portalorangeparrot:  Deployment to Live pending approval  :portalblueparrot:"
-          include_job_number_field: false
-          requires:
-            - deploy_staging
-      - confirm_production_deploy:
-          type: approval
-          requires:
-            - deploy_staging
-          filters:
-            branches:
-              only: master
-      - deploy_production:
-          context: *context
-          requires:
-            - confirm_production_deploy
-          filters:
-            branches:
-              only: master
+                - send-submission-id
+      # - slack/approval-notification:
+      #     message: ":portalorangeparrot:  Deployment to Live pending approval  :portalblueparrot:"
+      #     include_job_number_field: false
+      #     requires:
+      #       - deploy_staging
+      # - confirm_production_deploy:
+      #     type: approval
+      #     requires:
+      #       - deploy_staging
+      #     filters:
+      #       branches:
+      #         only: master
+      # - deploy_production:
+      #     context: *context
+      #     requires:
+      #       - confirm_production_deploy
+      #     filters:
+      #       branches:
+      #         only: master

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -20,7 +20,7 @@ class ApplicationJob < ActiveJob::Base
   end
 
   def previously_processed?(submission_id)
-    ProcessedSubmission.exists?(submission_id) ||
+    ProcessedSubmission.exists?(submission_id: submission_id) ||
       case_exists_in_optics?(submission_id)
   end
 

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -19,10 +19,12 @@ class ApplicationJob < ActiveJob::Base
     )
   end
 
+  # rubocop:disable Style/HashSyntax
   def previously_processed?(submission_id)
     ProcessedSubmission.exists?(submission_id: submission_id) ||
       case_exists_in_optics?(submission_id)
   end
+  # rubocop:enable Style/HashSyntax
 
   # rubocop:disable Metrics/MethodLength
   def case_exists_in_optics?(submission_id)

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -20,7 +20,7 @@ class ApplicationJob < ActiveJob::Base
   end
 
   def previously_processed?(submission_id)
-    ProcessedSubmission.exists?(submission_id: submission_id) ||
+    ProcessedSubmission.exists?(submission_id) ||
       case_exists_in_optics?(submission_id)
   end
 

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -19,6 +19,28 @@ class ApplicationJob < ActiveJob::Base
     )
   end
 
+  def previously_processed?(submission_id)
+    ProcessedSubmission.exists?(submission_id: submission_id) ||
+      case_exists_in_optics?(submission_id)
+  end
+
+  # rubocop:disable Metrics/MethodLength
+  def case_exists_in_optics?(submission_id)
+    result = gateway.get_case_attribute(submission_id, bearer_token.execute)
+    if result.success?
+      Rails.logger.info(
+        "Case with submission ID #{submission_id} already exists in OPTICS\nRecording previously processed submission"
+      )
+      record_successful_submission(submission_id)
+    end
+    result.success?
+  rescue Gateway::Optics::ClientError => e
+    Raven.capture_exception(e)
+    Rails.logger.warn(e.message)
+    raise(e)
+  end
+  # rubocop:enable Metrics/MethodLength
+
   def gateway
     Gateway::Optics.new(endpoint: Rails.configuration.x.optics.endpoint)
   end

--- a/app/jobs/send_comment_job.rb
+++ b/app/jobs/send_comment_job.rb
@@ -3,6 +3,7 @@ class SendCommentJob < ApplicationJob
 
   def perform(form_builder_payload:)
     return if previously_processed?(form_builder_payload[:submissionId])
+
     presenter = Presenter::Comment.new(
       form_builder_payload:
     )

--- a/app/jobs/send_comment_job.rb
+++ b/app/jobs/send_comment_job.rb
@@ -2,6 +2,7 @@ class SendCommentJob < ApplicationJob
   queue_as :send_comments
 
   def perform(form_builder_payload:)
+    return if previously_processed?(form_builder_payload[:submissionId])
     presenter = Presenter::Comment.new(
       form_builder_payload:
     )

--- a/app/jobs/send_comment_job.rb
+++ b/app/jobs/send_comment_job.rb
@@ -3,7 +3,10 @@ class SendCommentJob < ApplicationJob
 
   def perform(form_builder_payload:)
     return if previously_processed?(form_builder_payload[:submissionId])
+<<<<<<< HEAD
 
+=======
+>>>>>>> 644faee (Update all jobs to check for existence of previous submissions)
     presenter = Presenter::Comment.new(
       form_builder_payload:
     )

--- a/app/jobs/send_comment_job.rb
+++ b/app/jobs/send_comment_job.rb
@@ -3,10 +3,6 @@ class SendCommentJob < ApplicationJob
 
   def perform(form_builder_payload:)
     return if previously_processed?(form_builder_payload[:submissionId])
-<<<<<<< HEAD
-
-=======
->>>>>>> 644faee (Update all jobs to check for existence of previous submissions)
     presenter = Presenter::Comment.new(
       form_builder_payload:
     )

--- a/app/jobs/send_complaint_job.rb
+++ b/app/jobs/send_complaint_job.rb
@@ -3,6 +3,8 @@ class SendComplaintJob < ApplicationJob
 
   # rubocop:disable Metrics/MethodLength
   def perform(form_builder_payload:)
+    return if previously_processed?(form_builder_payload[:submissionId])
+
     Rails.logger.info("Working on job_id: #{job_id}")
 
     attachments = Usecase::SpawnAttachments.new(

--- a/app/jobs/send_correspondence_job.rb
+++ b/app/jobs/send_correspondence_job.rb
@@ -3,7 +3,10 @@ class SendCorrespondenceJob < ApplicationJob
 
   def perform(form_builder_payload:)
     return if previously_processed?(form_builder_payload[:submissionId])
+<<<<<<< HEAD
 
+=======
+>>>>>>> 644faee (Update all jobs to check for existence of previous submissions)
     presenter = Presenter::Correspondence.new(
       form_builder_payload:
     )

--- a/app/jobs/send_correspondence_job.rb
+++ b/app/jobs/send_correspondence_job.rb
@@ -2,6 +2,7 @@ class SendCorrespondenceJob < ApplicationJob
   queue_as :send_correspondences
 
   def perform(form_builder_payload:)
+    return if previously_processed?(form_builder_payload[:submissionId])
     presenter = Presenter::Correspondence.new(
       form_builder_payload:
     )

--- a/app/jobs/send_correspondence_job.rb
+++ b/app/jobs/send_correspondence_job.rb
@@ -3,10 +3,6 @@ class SendCorrespondenceJob < ApplicationJob
 
   def perform(form_builder_payload:)
     return if previously_processed?(form_builder_payload[:submissionId])
-<<<<<<< HEAD
-
-=======
->>>>>>> 644faee (Update all jobs to check for existence of previous submissions)
     presenter = Presenter::Correspondence.new(
       form_builder_payload:
     )

--- a/app/jobs/send_correspondence_job.rb
+++ b/app/jobs/send_correspondence_job.rb
@@ -3,6 +3,7 @@ class SendCorrespondenceJob < ApplicationJob
 
   def perform(form_builder_payload:)
     return if previously_processed?(form_builder_payload[:submissionId])
+
     presenter = Presenter::Correspondence.new(
       form_builder_payload:
     )

--- a/app/jobs/send_feedback_job.rb
+++ b/app/jobs/send_feedback_job.rb
@@ -3,10 +3,6 @@ class SendFeedbackJob < ApplicationJob
 
   def perform(form_builder_payload:)
     return if previously_processed?(form_builder_payload[:submissionId])
-<<<<<<< HEAD
-
-=======
->>>>>>> 644faee (Update all jobs to check for existence of previous submissions)
     presenter = Presenter::Feedback.new(
       form_builder_payload:
     )

--- a/app/jobs/send_feedback_job.rb
+++ b/app/jobs/send_feedback_job.rb
@@ -2,6 +2,7 @@ class SendFeedbackJob < ApplicationJob
   queue_as :send_feedback
 
   def perform(form_builder_payload:)
+    return if previously_processed?(form_builder_payload[:submissionId])
     presenter = Presenter::Feedback.new(
       form_builder_payload:
     )

--- a/app/jobs/send_feedback_job.rb
+++ b/app/jobs/send_feedback_job.rb
@@ -3,7 +3,10 @@ class SendFeedbackJob < ApplicationJob
 
   def perform(form_builder_payload:)
     return if previously_processed?(form_builder_payload[:submissionId])
+<<<<<<< HEAD
 
+=======
+>>>>>>> 644faee (Update all jobs to check for existence of previous submissions)
     presenter = Presenter::Feedback.new(
       form_builder_payload:
     )

--- a/app/jobs/send_feedback_job.rb
+++ b/app/jobs/send_feedback_job.rb
@@ -3,6 +3,7 @@ class SendFeedbackJob < ApplicationJob
 
   def perform(form_builder_payload:)
     return if previously_processed?(form_builder_payload[:submissionId])
+
     presenter = Presenter::Feedback.new(
       form_builder_payload:
     )

--- a/app/lib/gateway/optics.rb
+++ b/app/lib/gateway/optics.rb
@@ -14,6 +14,7 @@ module Gateway
     def initialize(endpoint:)
       @get_token_url = "#{endpoint}/token?db=hmcts".freeze
       @post_case_url = "#{endpoint}/createcase?db=hmcts".freeze
+      @get_case_attribute_url = "#{endpoint}/getcaseattribute?db=hmcts&Format=json&Attribute=CaseId&ExternalId=".freeze
     end
 
     def request_bearer_token(jwt_token:)
@@ -28,6 +29,12 @@ module Gateway
       return result if result.success?
 
       raise ClientError, result
+    end
+
+    def get_case_attribute(submission_id, bearer_token)
+      HTTParty.get("#{@get_case_attribute_url}#{submission_id}", headers: headers(bearer_token))
+    rescue HTTParty::Error => e
+      raise ClientError, e
     end
 
     private

--- a/app/lib/gateway/optics.rb
+++ b/app/lib/gateway/optics.rb
@@ -7,7 +7,10 @@ module Gateway
       end
 
       def to_s
-        "[OPTICS API error: Received #{@response&.code} response, with headers #{@response&.headers}] #{super}"
+        message = "[OPTICS API error: Received #{@response&.code} response, with headers #{@response&.headers}]"
+        "#{message} #{super}"
+      rescue StandardError
+        message
       end
     end
 

--- a/app/lib/presenter/comment.rb
+++ b/app/lib/presenter/comment.rb
@@ -19,9 +19,5 @@ module Presenter
     def type
       ENV['COMMENT_TYPE'] || ''
     end
-
-    def submission_answers
-      @submission_answers ||= form_builder_payload.fetch(:submissionAnswers)
-    end
   end
 end

--- a/app/lib/presenter/comment.rb
+++ b/app/lib/presenter/comment.rb
@@ -9,7 +9,8 @@ module Presenter
         RequestMethod: REQUEST_METHOD,
         AssignedTeam: submission_answers.fetch(:contact_location, ''),
         'Case.ServiceTeam': submission_answers.fetch(:contact_location, ''),
-        Details: submission_answers.fetch(:feedback_details, '')
+        Details: submission_answers.fetch(:feedback_details, ''),
+        ExternalId: form_builder_payload.fetch(:submissionId)
       }
     end
 
@@ -17,6 +18,10 @@ module Presenter
 
     def type
       ENV['COMMENT_TYPE'] || ''
+    end
+
+    def submission_answers
+      @submission_answers ||= form_builder_payload.fetch(:submissionAnswers)
     end
   end
 end

--- a/app/lib/presenter/complaint.rb
+++ b/app/lib/presenter/complaint.rb
@@ -60,9 +60,5 @@ module Presenter
         'PartyContextManageCases': 'Main'
       }
     end
-
-    def submission_answers
-      @submission_answers ||= form_builder_payload.fetch(:submissionAnswers)
-    end
   end
 end

--- a/app/lib/presenter/complaint.rb
+++ b/app/lib/presenter/complaint.rb
@@ -12,7 +12,8 @@ module Presenter
         AssignedTeamSS: submission_answers.fetch(:complaint_location),
         RequestDate: request_date,
         Details: submission_answers.fetch(:complaint_details, ''),
-        Reference: submission_answers.fetch(:case_number, '')
+        Reference: submission_answers.fetch(:case_number, ''),
+        ExternalId: form_builder_payload.fetch(:submissionId)
       }.merge(constant_data, customer_data, *attachments_data)
     end
 
@@ -58,6 +59,10 @@ module Presenter
         RequestMethod: 'Online - gov.uk',
         'PartyContextManageCases': 'Main'
       }
+    end
+
+    def submission_answers
+      @submission_answers ||= form_builder_payload.fetch(:submissionAnswers)
     end
   end
 end

--- a/app/lib/presenter/correspondence.rb
+++ b/app/lib/presenter/correspondence.rb
@@ -36,6 +36,7 @@ module Presenter
         Details: submission_answers.fetch(:MessageContent, ''),
         QueryType: QUERY_TYPE.fetch(query_type_claimant_or_defendant, ''),
         ServiceType: service_type,
+        ExternalId: form_builder_payload.fetch(:submissionId),
         'CaseContactPostcode.Subject': submission_answers.fetch(:ClientPostcode, ''),
         'CaseContactCustom17.Representative': submission_answers.fetch(:CompanyName, ''),
         'CaseContactCustom18.Subject': '',
@@ -126,6 +127,10 @@ module Presenter
     def existing_case_reference?
       @existing_case_reference ||=
         submission_answers.fetch(:ClaimNumber, '') == EXISTING_CASE_REFERENCE
+    end
+
+    def submission_answers
+      @submission_answers ||= form_builder_payload.fetch(:submissionAnswers)
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/app/lib/presenter/correspondence.rb
+++ b/app/lib/presenter/correspondence.rb
@@ -128,10 +128,6 @@ module Presenter
       @existing_case_reference ||=
         submission_answers.fetch(:ClaimNumber, '') == EXISTING_CASE_REFERENCE
     end
-
-    def submission_answers
-      @submission_answers ||= form_builder_payload.fetch(:submissionAnswers)
-    end
   end
   # rubocop:enable Metrics/ClassLength
 end

--- a/app/lib/presenter/feedback.rb
+++ b/app/lib/presenter/feedback.rb
@@ -19,11 +19,5 @@ module Presenter
       }
     end
     # rubocop:enable Metrics/MethodLength
-
-    private
-
-    def submission_answers
-      @submission_answers ||= form_builder_payload.fetch(:submissionAnswers)
-    end
   end
 end

--- a/app/lib/presenter/feedback.rb
+++ b/app/lib/presenter/feedback.rb
@@ -4,6 +4,7 @@ module Presenter
     TYPE = 'UF144908'.freeze
     PARTY_CONTEXT = 'Main'.freeze
 
+    # rubocop:disable Metrics/MethodLength
     def optics_payload
       {
         Type: TYPE,
@@ -13,8 +14,16 @@ module Presenter
         'External.RequestMethod': REQUEST_METHOD,
         PartyContext: PARTY_CONTEXT,
         AssignedTeam: submission_answers.fetch(:contact_location, ''),
-        Details: submission_answers.fetch(:feedback_details, '')
+        Details: submission_answers.fetch(:feedback_details, ''),
+        ExternalId: form_builder_payload.fetch(:submissionId)
       }
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    private
+
+    def submission_answers
+      @submission_answers ||= form_builder_payload.fetch(:submissionAnswers)
     end
   end
 end

--- a/spec/gateway/optics_spec.rb
+++ b/spec/gateway/optics_spec.rb
@@ -42,7 +42,7 @@ describe Gateway::Optics do
         end.to raise_error(Gateway::Optics::ClientError)
       end
 
-      it 'returns the status code and headders in an error' do
+      it 'returns the status code and headers in an error' do
         expect do
           gateway.request_bearer_token(jwt_token: 'foo')
         end.to raise_error(Gateway::Optics::ClientError)
@@ -99,6 +99,37 @@ describe Gateway::Optics do
           gateway.post(body: {}, bearer_token: bearer_token)
         end.to raise_error(Gateway::Optics::ClientError)
           .with_message(%r{\[OPTICS API error: Received 500 response, with headers {"error-header"=>\["some message"\]}\] <html>errors return xml body</error>})
+      end
+    end
+  end
+
+  describe '#get_case_attribute' do
+    let(:submission_id) { SecureRandom.uuid }
+    let(:headers) do
+      {
+        'Content-Type' => 'application/json',
+        'Authorization' => "Bearer #{bearer_token}"
+      }
+    end
+    let(:request_uri) do
+      "#{endpoint}/getcaseattribute?db=hmcts&Format=json&Attribute=CaseId&ExternalId=#{submission_id}"
+    end
+
+    it 'requests the case attribute from OPTICS' do
+      expect(HTTParty).to receive(:get).with(request_uri, headers: headers)
+
+      gateway.get_case_attribute(submission_id, bearer_token)
+    end
+
+    context 'when there is an error communicating with OPTICS' do
+      before do
+        allow(HTTParty).to receive(:get).and_raise(HTTParty::Error.new('something something something dark side'))
+      end
+
+      it 'raises a client error' do
+        expect {
+          gateway.get_case_attribute(submission_id, bearer_token)
+        }.to raise_error(Gateway::Optics::ClientError)
       end
     end
   end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -1,0 +1,65 @@
+RSpec.shared_examples 'an application job' do
+  let(:submission_id) { SecureRandom.uuid }
+
+  context 'submission exists in database' do
+    before do
+      ProcessedSubmission.create(submission_id: submission_id)
+    end
+
+    it 'should not process the submission again' do
+      expect(create_case).not_to receive(:execute)
+      jobs.perform(form_builder_payload: input)
+    end
+  end
+
+  context 'submission not in db but exists in optics' do
+    let(:result) { double(success?: true) }
+
+    before do
+      allow(gateway).to receive(:get_case_attribute).and_return(result)
+    end
+
+    it 'should not process the submission again' do
+      expect(create_case).not_to receive(:execute)
+      jobs.perform(form_builder_payload: input)
+    end
+
+    it 'should create the processed submission record in the db' do
+      jobs.perform(form_builder_payload: input)
+      expect(ProcessedSubmission.find_by(submission_id: submission_id)).to be_present
+    end
+  end
+
+  context 'when the case does not exist in database or in optics' do
+    let(:result) { double(success?: false) }
+
+    before do
+      allow(gateway).to receive(:get_case_attribute).and_return(result)
+    end
+
+    it 'should process the submission' do
+      expect(create_case).to receive(:execute)
+      jobs.perform(form_builder_payload: input)
+    end
+
+    it 'should create the processed submission record in the db' do
+      jobs.perform(form_builder_payload: input)
+      expect(ProcessedSubmission.find_by(submission_id: submission_id)).to be_present
+    end
+  end
+
+  context 'when there is an error communicating with OPTICS' do
+    let(:error) { Gateway::Optics::ClientError.new('some error message') }
+
+    before do
+      allow(gateway).to receive(:get_case_attribute).and_raise(error)
+    end
+
+    it 'should not process the submission' do
+      expect(create_case).not_to receive(:execute)
+      expect(Raven).to receive(:capture_exception).with(error)
+      expect(Rails.logger).to receive(:warn).with(error.message)
+      expect { jobs.perform(form_builder_payload: input) }.to raise_error(Gateway::Optics::ClientError)
+    end
+  end
+end

--- a/spec/jobs/send_comment_job_spec.rb
+++ b/spec/jobs/send_comment_job_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require_relative 'application_job_spec'
 
 RSpec.describe SendCommentJob, type: :job do
   describe '#perform_later' do
@@ -19,8 +20,10 @@ RSpec.describe SendCommentJob, type: :job do
     let(:create_case) { instance_spy(Usecase::Optics::CreateCase) }
     let(:presenter) { instance_spy(Presenter::Comment) }
     let(:gateway) { instance_spy(Gateway::Optics) }
+    let(:submission_id) { SecureRandom.uuid }
     let(:input) do
       {
+        'submissionId': submission_id,
         'submissionAnswers': {
           contact_location: '1111',
           feedback_details: 'all of the feedback'
@@ -54,11 +57,19 @@ RSpec.describe SendCommentJob, type: :job do
       allow(Gateway::Optics).to receive(:new).and_return(gateway)
     end
 
-    context 'when the a submission was submitted to Optics' do
+    context 'when the a submission was submitted to Optics for the first time' do
+      before do
+        allow(jobs).to receive(:previously_processed?).and_return(false)
+      end
+
       it 'creates a new entry' do
         jobs.perform(form_builder_payload: input)
         expect(ProcessedSubmission.count).to eq(1)
       end
+    end
+
+    it_behaves_like 'an application job' do
+      let(:job_type) { 'send_comments' }
     end
   end
 end

--- a/spec/presenter/complaint_spec.rb
+++ b/spec/presenter/complaint_spec.rb
@@ -6,10 +6,11 @@ describe Presenter::Complaint do
                         attachments: attachments)
   end
 
+  let(:submission_id) { '1e937616-dd0b-4bc3-8c67-40e4ffd54f78' }
   let(:input_payload) do
     {
       'serviceSlug': 'my-form',
-      'submissionId': '1e937616-dd0b-4bc3-8c67-40e4ffd54f78',
+      'submissionId': submission_id,
       'submissionAnswers': {
         'first_name': 'Jim',
         'last_name': 'Complainer',
@@ -55,6 +56,7 @@ describe Presenter::Complaint do
       AssignedTeamSS: '1001',
       RequestDate: '2019-09-11',
       Reference: '12345',
+      ExternalId: submission_id,
       "PartyContextManageCases": 'Main',
       "Customer.FirstName": 'Jim',
       "Customer.Surname": 'Complainer',
@@ -92,7 +94,7 @@ describe Presenter::Complaint do
     let(:invalid_input_payload) do
       {
         'serviceSlug': 'my-form',
-        'submissionId': '1e937616-dd0b-4bc3-8c67-40e4ffd54f78',
+        'submissionId': submission_id,
         'submissionAnswers': {
           'complaint_location': '1001'
         }
@@ -105,6 +107,7 @@ describe Presenter::Complaint do
         Type: 'Complaint',
         Format: 'json',
         Reference: '',
+        ExternalId: submission_id,
         RequestMethod: 'Online - gov.uk',
         "PartyContextManageCases": 'Main',
         RequestDate: Date.today.to_s,

--- a/spec/presenter/correspondence_spec.rb
+++ b/spec/presenter/correspondence_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Presenter::Correspondence do
     let(:base_payload) do
       {
         serviceSlug: 'money-claim-queries',
-        submissionId: '891c837c-adef-4854-8bd0-d681577f381e',
+        submissionId: submission_id,
         submissionAnswers:
         {
           ClaimNumber: 'CaseReferenceYes',
@@ -32,6 +32,7 @@ RSpec.describe Presenter::Correspondence do
         }.merge(input_payload)
       }
     end
+    let(:submission_id) { '891c837c-adef-4854-8bd0-d681577f381e' }
 
     context 'applicant type' do
       context 'when claimant' do
@@ -253,6 +254,7 @@ RSpec.describe Presenter::Correspondence do
           Details: 'some message body thing',
           QueryType: 'A',
           ServiceType: 'A',
+          ExternalId: submission_id,
           'Applicant1.Forename1': 'Qui Gon',
           'Applicant1.Name': 'Jinn',
           'Applicant1.Email': 'quigon@jedi-temple.com',
@@ -321,6 +323,7 @@ RSpec.describe Presenter::Correspondence do
           Details: 'some message body thing',
           QueryType: 'E',
           ServiceType: 'A',
+          ExternalId: submission_id,
           'Applicant1.Forename1': 'Darth',
           'Applicant1.Name': 'Maul',
           'Applicant1.Email': '',

--- a/spec/requests/comment_spec.rb
+++ b/spec/requests/comment_spec.rb
@@ -55,6 +55,7 @@ describe 'Submitting a comment', type: :request do
     end
   end
 
+  let(:submission_id) { '891c837c-adef-4854-8bd0-d681577f381e' }
   let(:expected_optics_payload) do
     {
       Type: '1801265',
@@ -62,14 +63,15 @@ describe 'Submitting a comment', type: :request do
       RequestMethod: Presenter::Comment::REQUEST_METHOD,
       AssignedTeam: '1111',
       'Case.ServiceTeam': '1111',
-      Details: 'all of the feedback'
+      Details: 'all of the feedback',
+      ExternalId: submission_id
     }.to_json
   end
 
   let(:runner_submission) do
     {
       serviceSlug: 'comments-form',
-      submissionId: '891c837c-adef-4854-8bd0-d681577f381e',
+      submissionId: submission_id,
       submissionAnswers:
       {
         contact_location: '1111',
@@ -112,7 +114,7 @@ describe 'Submitting a comment', type: :request do
       expect(ProcessedSubmission.count).to eq(1)
       expect(
         ProcessedSubmission.first.submission_id
-      ).to eq('891c837c-adef-4854-8bd0-d681577f381e')
+      ).to eq(submission_id)
     end
   end
 end

--- a/spec/requests/comment_spec.rb
+++ b/spec/requests/comment_spec.rb
@@ -8,9 +8,7 @@ describe 'Submitting a comment', type: :request do
 
     allow(ENV).to receive(:[]).with('COMMENT_TYPE').and_return('1801265')
 
-    allow(SecureRandom).to receive(:uuid).and_return(
-      'e2161d54-92f8-4e10-b3a1-94630c65df3c'
-    )
+    allow(SecureRandom).to receive(:uuid).and_return(submission_id)
 
     stub_request(:post, 'https://uat.icasework.com/token?db=hmcts')
     .with(
@@ -29,6 +27,19 @@ describe 'Submitting a comment', type: :request do
           access_token: 'some_bearer_token'
         }.to_json, headers: {}
       )
+
+    stub_request(
+      :get,
+      "https://uat.icasework.com/getcaseattribute?db=hmcts&Format=json&Attribute=CaseId&ExternalId=#{submission_id}"
+    ).with(
+      headers: {
+        'Accept'=>'*/*',
+        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'Authorization'=>'Bearer some_bearer_token',
+        'Content-Type'=>'application/json',
+        'User-Agent'=>'Ruby'
+      }
+    ).to_return(status: 400, body: '', headers: {}) # 400 means the case does NOT exist in OPTICS
 
     stub_request(:post, 'https://uat.icasework.com/createcase?db=hmcts')
       .with(
@@ -97,6 +108,17 @@ describe 'Submitting a comment', type: :request do
       expect(WebMock).to have_requested(:post, 'https://uat.icasework.com/token?db=hmcts').with(
         headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
         body: 'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzb21lX29wdGljc19hcGlfa2V5IiwiYXVkIjoiaHR0cHM6Ly91YXQuaWNhc2V3b3JrLmNvbS90b2tlbj9kYj1obWN0cyIsImlhdCI6MTY1MDkwMDg4Nn0.zR67gqqkz2PmgafsdBw_qFHWEDLhKsvvD9waJC3hbO8'
+      ).twice
+    end
+
+    it 'checks whether the submission has been previously processed' do
+      expect(WebMock).to have_requested(
+        :get, "https://uat.icasework.com/getcaseattribute?db=hmcts&Format=json&Attribute=CaseId&ExternalId=#{submission_id}"
+      ).with(
+        headers: {
+          'Authorization' => 'Bearer some_bearer_token',
+          'Content-Type' => 'application/json'
+        }
       ).once
     end
 

--- a/spec/requests/complaint_spec.rb
+++ b/spec/requests/complaint_spec.rb
@@ -33,6 +33,7 @@ describe 'Submitting a complaint', type: :request do
     end
   end
 
+  let(:submission_id) { '891c837c-adef-4854-8bd0-d681577f381e' }
   let(:expected_optics_payload) do
     {
       Team: '111',
@@ -41,6 +42,7 @@ describe 'Submitting a complaint', type: :request do
       RequestDate: Date.today.to_s,
       Details: '',
       Reference: '',
+      ExternalId: submission_id,
       db: 'hmcts',
       Type: 'Complaint',
       Format: 'json',
@@ -66,7 +68,7 @@ describe 'Submitting a complaint', type: :request do
   let(:runner_submission) do
     {
       serviceSlug: 'claim-for-the-costs-of-a-something',
-      submissionId: '891c837c-adef-4854-8bd0-d681577f381e',
+      submissionId: submission_id,
       submissionAnswers:
       {
         fullname: 'Full Name',
@@ -115,7 +117,7 @@ describe 'Submitting a complaint', type: :request do
       expect(ProcessedSubmission.count).to eq(1)
       expect(
         ProcessedSubmission.first.submission_id
-      ).to eq('891c837c-adef-4854-8bd0-d681577f381e')
+      ).to eq(submission_id)
     end
   end
 end

--- a/spec/requests/correspondence_spec.rb
+++ b/spec/requests/correspondence_spec.rb
@@ -112,9 +112,7 @@ describe 'Submitting a correspondence', type: :request do
   before do
     Timecop.freeze(Time.parse('2019-09-11 15:34:46 +0000'))
 
-    allow(SecureRandom).to receive(:uuid).and_return(
-      'e2161d54-92f8-4e10-b3a1-94630c65df3c'
-    )
+    allow(SecureRandom).to receive(:uuid).and_return(submission_id)
 
     stub_request(:post, 'https://uat.icasework.com/token?db=hmcts')
       .with(
@@ -129,6 +127,19 @@ describe 'Submitting a correspondence', type: :request do
           access_token: 'some_bearer_token'
         }.to_json, headers: {}
       )
+
+    stub_request(
+      :get,
+      "https://uat.icasework.com/getcaseattribute?db=hmcts&Format=json&Attribute=CaseId&ExternalId=#{submission_id}"
+    ).with(
+      headers: {
+        'Accept'=>'*/*',
+        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'Authorization'=>'Bearer some_bearer_token',
+        'Content-Type'=>'application/json',
+        'User-Agent'=>'Ruby'
+      }
+    ).to_return(status: 400, body: '', headers: {}) # 400 means the case does NOT exist in OPTICS
 
     stub_request(:post, 'https://uat.icasework.com/createcase?db=hmcts')
       .with(
@@ -165,6 +176,17 @@ describe 'Submitting a correspondence', type: :request do
         expect(WebMock).to have_requested(:post, 'https://uat.icasework.com/token?db=hmcts').with(
           headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
           body: 'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzb21lX29wdGljc19hcGlfa2V5IiwiYXVkIjoiaHR0cHM6Ly91YXQuaWNhc2V3b3JrLmNvbS90b2tlbj9kYj1obWN0cyIsImlhdCI6MTU2ODIxNjA4Nn0.fj8VsMONpeEmeavkh23yRsGAtfVlWkJI267gijpy6pA'
+        ).twice
+      end
+
+      it 'checks whether the submission has been previously processed' do
+        expect(WebMock).to have_requested(
+          :get, "https://uat.icasework.com/getcaseattribute?db=hmcts&Format=json&Attribute=CaseId&ExternalId=#{submission_id}"
+        ).with(
+          headers: {
+            'Authorization' => 'Bearer some_bearer_token',
+            'Content-Type' => 'application/json'
+          }
         ).once
       end
 
@@ -206,6 +228,17 @@ describe 'Submitting a correspondence', type: :request do
         expect(WebMock).to have_requested(:post, 'https://uat.icasework.com/token?db=hmcts').with(
           headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
           body: 'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzb21lX29wdGljc19hcGlfa2V5IiwiYXVkIjoiaHR0cHM6Ly91YXQuaWNhc2V3b3JrLmNvbS90b2tlbj9kYj1obWN0cyIsImlhdCI6MTU2ODIxNjA4Nn0.fj8VsMONpeEmeavkh23yRsGAtfVlWkJI267gijpy6pA'
+        ).twice
+      end
+
+      it 'checks whether the submission has been previously processed' do
+        expect(WebMock).to have_requested(
+          :get, "https://uat.icasework.com/getcaseattribute?db=hmcts&Format=json&Attribute=CaseId&ExternalId=#{submission_id}"
+        ).with(
+          headers: {
+            'Authorization' => 'Bearer some_bearer_token',
+            'Content-Type' => 'application/json'
+          }
         ).once
       end
 

--- a/spec/requests/correspondence_spec.rb
+++ b/spec/requests/correspondence_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe 'Submitting a correspondence', type: :request do
   include ActiveJob::TestHelper
 
+  let(:submission_id) { '891c837c-adef-4854-8bd0-d681577f381e' }
   let(:constant_data) do
     {
       db: Presenter::Correspondence::DB,
@@ -20,6 +21,7 @@ describe 'Submitting a correspondence', type: :request do
       Details: 'some message body thing',
       QueryType: 'B',
       ServiceType: 'A',
+      ExternalId: submission_id,
       'CaseContactPostcode.Subject': 'W1 1CA',
       'CaseContactCustom17.Representative': 'Jedi Council',
       'CaseContactCustom18.Subject': '',
@@ -37,7 +39,7 @@ describe 'Submitting a correspondence', type: :request do
   let(:representing_runner_submission) do
     {
       serviceSlug: 'money-claim-queries',
-      submissionId: '891c837c-adef-4854-8bd0-d681577f381e',
+      submissionId: submission_id,
       submissionAnswers:
       {
         ClaimNumber: 'CaseReferenceYes',
@@ -67,6 +69,7 @@ describe 'Submitting a correspondence', type: :request do
       Details: 'some message body thing',
       QueryType: 'B',
       ServiceType: 'A',
+      ExternalId: submission_id,
       'CaseContactPostcode.Subject': '',
       'CaseContactCustom17.Representative': '',
       'CaseContactCustom18.Subject': '',
@@ -84,7 +87,7 @@ describe 'Submitting a correspondence', type: :request do
   let(:self_representing_runner_submission) do
     {
       serviceSlug: 'money-claim-queries',
-      submissionId: '891c837c-adef-4854-8bd0-d681577f381e',
+      submissionId: submission_id,
       submissionAnswers:
       {
         NewOrExistingClaim: 'new-claim',
@@ -181,7 +184,7 @@ describe 'Submitting a correspondence', type: :request do
         expect(ProcessedSubmission.count).to eq(1)
         expect(
           ProcessedSubmission.first.submission_id
-        ).to eq('891c837c-adef-4854-8bd0-d681577f381e')
+        ).to eq(submission_id)
       end
     end
   end
@@ -222,7 +225,7 @@ describe 'Submitting a correspondence', type: :request do
         expect(ProcessedSubmission.count).to eq(1)
         expect(
           ProcessedSubmission.first.submission_id
-        ).to eq('891c837c-adef-4854-8bd0-d681577f381e')
+        ).to eq(submission_id)
       end
     end
   end

--- a/spec/requests/feedback_spec.rb
+++ b/spec/requests/feedback_spec.rb
@@ -6,9 +6,7 @@ describe 'Submitting feedback', type: :request do
   before do
     Timecop.freeze(Time.parse('2022-05-04 15:34:46 +0000'))
 
-    allow(SecureRandom).to receive(:uuid).and_return(
-      'e2161d54-92f8-4e10-b3a1-94630c65df3c'
-    )
+    allow(SecureRandom).to receive(:uuid).and_return(submission_id)
 
     stub_request(:post, 'https://uat.icasework.com/token?db=hmcts')
     .with(
@@ -27,6 +25,19 @@ describe 'Submitting feedback', type: :request do
           access_token: 'some_bearer_token'
         }.to_json, headers: {}
       )
+
+    stub_request(
+      :get,
+      "https://uat.icasework.com/getcaseattribute?db=hmcts&Format=json&Attribute=CaseId&ExternalId=#{submission_id}"
+    ).with(
+      headers: {
+        'Accept'=>'*/*',
+        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'Authorization'=>'Bearer some_bearer_token',
+        'Content-Type'=>'application/json',
+        'User-Agent'=>'Ruby'
+      }
+    ).to_return(status: 400, body: '', headers: {}) # 400 means the case does NOT exist in OPTICS
 
     stub_request(:post, 'https://uat.icasework.com/createcase?db=hmcts')
       .with(
@@ -97,6 +108,17 @@ describe 'Submitting feedback', type: :request do
       expect(WebMock).to have_requested(:post, 'https://uat.icasework.com/token?db=hmcts').with(
         headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
         body: 'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzb21lX29wdGljc19hcGlfa2V5IiwiYXVkIjoiaHR0cHM6Ly91YXQuaWNhc2V3b3JrLmNvbS90b2tlbj9kYj1obWN0cyIsImlhdCI6MTY1MTY3ODQ4Nn0.7f-8HNHcxUK5KV6K5yWUf5C7krkjNANv6it6ADa33FY'
+      ).twice
+    end
+
+    it 'checks whether the submission has been previously processed' do
+      expect(WebMock).to have_requested(
+        :get, "https://uat.icasework.com/getcaseattribute?db=hmcts&Format=json&Attribute=CaseId&ExternalId=#{submission_id}"
+      ).with(
+        headers: {
+          'Authorization' => 'Bearer some_bearer_token',
+          'Content-Type' => 'application/json'
+        }
       ).once
     end
 

--- a/spec/requests/feedback_spec.rb
+++ b/spec/requests/feedback_spec.rb
@@ -53,6 +53,7 @@ describe 'Submitting feedback', type: :request do
     end
   end
 
+  let(:submission_id) { '891c837c-adef-4854-8bd0-d681577f381e' }
   let(:expected_optics_payload) do
     {
       Type:  Presenter::Feedback::TYPE,
@@ -62,14 +63,15 @@ describe 'Submitting feedback', type: :request do
       'External.RequestMethod': Presenter::Feedback::REQUEST_METHOD,
       PartyContext: Presenter::Feedback::PARTY_CONTEXT,
       AssignedTeam: '1111',
-      Details: 'all of the feedback'
+      Details: 'all of the feedback',
+      ExternalId: submission_id
     }.to_json
   end
 
   let(:runner_submission) do
     {
       serviceSlug: 'user-feedback-form',
-      submissionId: '891c837c-adef-4854-8bd0-d681577f381e',
+      submissionId: submission_id,
       submissionAnswers:
       {
         contact_location: '1111',
@@ -112,7 +114,7 @@ describe 'Submitting feedback', type: :request do
       expect(ProcessedSubmission.count).to eq(1)
       expect(
         ProcessedSubmission.first.submission_id
-      ).to eq('891c837c-adef-4854-8bd0-d681577f381e')
+      ).to eq(submission_id)
     end
   end
 end


### PR DESCRIPTION
## Add submission ID to all OPTICS payloads

In order for the adapter to be able to check whether OPTICS has received
a submission previously we need to send the submission ID for every
submission in the payload. We do this by adding it as an ExternalId.
Optics will then save this as an additional property in their database.

## Update all jobs to check for existence of previous submissions

Before allowing each job to post the submission payload to the OPTICS we
check whether OPTICS has previously received that a payload containing
the submission id. We do this by requesting an attribute for a specific
case passing the submission ID as the ExternalId URL parameter.

OPTICS will return a 200 if it has a case which has that submission ID
as an ExternalId. If this is the case we will then add a
ProcessedSubmission record with that submission ID to the DB.

If it does not have a case with that ExternalId then it will return a
400. In this event, as a case with that submission ID does not exist in
OPTICS, we want to post the submission in order to create the case as
normal.

In the event of a networking error communicating with OPTICS to check
for a previously processed submission we fail and the job should retry
a little later.

<img width="1063" alt="Screenshot 2022-12-07 at 14 16 57" src="https://user-images.githubusercontent.com/3466862/206202518-9217e1cb-029b-4828-9167-cec3813bf21f.png">

