### PR TITLE
Migration from FormBuilder to MoJ Forms

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,22 +104,23 @@ workflows:
               only:
                 - master
                 - deploy-to-staging
-      - slack/approval-notification:
-          message: ":portalorangeparrot:  Deployment to Live pending approval  :portalblueparrot:"
-          include_job_number_field: false
-          requires:
-            - deploy_staging
-      - confirm_production_deploy:
-          type: approval
-          requires:
-            - deploy_staging
-          filters:
-            branches:
-              only: master
-      - deploy_production:
-          context: *context
-          requires:
-            - confirm_production_deploy
-          filters:
-            branches:
-              only: master
+                - migration-mojforms
+      # - slack/approval-notification:
+      #     message: ":portalorangeparrot:  Deployment to Live pending approval  :portalblueparrot:"
+      #     include_job_number_field: false
+      #     requires:
+      #       - deploy_staging
+      # - confirm_production_deploy:
+      #     type: approval
+      #     requires:
+      #       - deploy_staging
+      #     filters:
+      #       branches:
+      #         only: master
+      # - deploy_production:
+      #     context: *context
+      #     requires:
+      #       - confirm_production_deploy
+      #     filters:
+      #       branches:
+      #         only: master

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -302,4 +302,4 @@ RUBY VERSION
    ruby 3.1.3p185
 
 BUNDLED WITH
-   2.1.4
+   2.4.15

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,4 +28,8 @@ class ApplicationController < ActionController::API
   def render_unauthorized
     render status: :unauthorized
   end
+
+  def api_version
+    @api_version = params[:api_version].blank? ? 'v1' : params[:api_version]
+  end
 end

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -1,6 +1,6 @@
 class CommentController < ApplicationController
   def create
-    SendCommentJob.perform_later(form_builder_payload: @decrypted_body, api_version: @api_version)
+    SendCommentJob.perform_later(form_builder_payload: @decrypted_body, api_version:)
 
     render json: { placeholder: true }, status: 201
   end

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -1,6 +1,6 @@
 class CommentController < ApplicationController
   def create
-    SendCommentJob.perform_later(form_builder_payload: @decrypted_body)
+    SendCommentJob.perform_later(form_builder_payload: @decrypted_body, api_version: @api_version)
 
     render json: { placeholder: true }, status: 201
   end

--- a/app/controllers/complaint_controller.rb
+++ b/app/controllers/complaint_controller.rb
@@ -1,6 +1,6 @@
 class ComplaintController < ApplicationController
   def create
-    SendComplaintJob.perform_later(form_builder_payload: @decrypted_body, api_version: @api_version)
+    SendComplaintJob.perform_later(form_builder_payload: @decrypted_body, api_version:)
 
     render json: { placeholder: true }, status: 201
   end

--- a/app/controllers/complaint_controller.rb
+++ b/app/controllers/complaint_controller.rb
@@ -1,7 +1,7 @@
 class ComplaintController < ApplicationController
   def create
     SendComplaintJob.perform_later(form_builder_payload: @decrypted_body, api_version:)
-
+    Rails.logger.warn('Created Job')
     render json: { placeholder: true }, status: 201
   end
 end

--- a/app/controllers/complaint_controller.rb
+++ b/app/controllers/complaint_controller.rb
@@ -1,6 +1,6 @@
 class ComplaintController < ApplicationController
   def create
-    SendComplaintJob.perform_later(form_builder_payload: @decrypted_body, api_version: @api_version)
+    SendComplaintJob.perform_later(form_builder_payload: @decrypted_body, api_version:)
     Rails.logger.warn('Created Job')
     render json: { placeholder: true }, status: 201
   end

--- a/app/controllers/complaint_controller.rb
+++ b/app/controllers/complaint_controller.rb
@@ -1,7 +1,6 @@
 class ComplaintController < ApplicationController
   def create
     SendComplaintJob.perform_later(form_builder_payload: @decrypted_body, api_version:)
-    Rails.logger.warn('Created Job')
     render json: { placeholder: true }, status: 201
   end
 end

--- a/app/controllers/complaint_controller.rb
+++ b/app/controllers/complaint_controller.rb
@@ -1,6 +1,6 @@
 class ComplaintController < ApplicationController
   def create
-    SendComplaintJob.perform_later(form_builder_payload: @decrypted_body, api_version:)
+    SendComplaintJob.perform_later(form_builder_payload: @decrypted_body, api_version: @api_version)
     Rails.logger.warn('Created Job')
     render json: { placeholder: true }, status: 201
   end

--- a/app/controllers/complaint_controller.rb
+++ b/app/controllers/complaint_controller.rb
@@ -1,6 +1,6 @@
 class ComplaintController < ApplicationController
   def create
-    SendComplaintJob.perform_later(form_builder_payload: @decrypted_body)
+    SendComplaintJob.perform_later(form_builder_payload: @decrypted_body, api_version: @api_version)
 
     render json: { placeholder: true }, status: 201
   end

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,6 +1,6 @@
 class FeedbackController < ApplicationController
   def create
-    SendFeedbackJob.perform_later(form_builder_payload: @decrypted_body, api_version: params[:api_version])
+    SendFeedbackJob.perform_later(form_builder_payload: @decrypted_body, api_version: @api_version)
 
     render json: { placeholder: true }, status: 201
   end

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,6 +1,6 @@
 class FeedbackController < ApplicationController
   def create
-    SendFeedbackJob.perform_later(form_builder_payload: @decrypted_body)
+    SendFeedbackJob.perform_later(form_builder_payload: @decrypted_body, api_version: params[:api_version])
 
     render json: { placeholder: true }, status: 201
   end

--- a/app/jobs/send_comment_job.rb
+++ b/app/jobs/send_comment_job.rb
@@ -3,6 +3,7 @@ class SendCommentJob < ApplicationJob
 
   def perform(form_builder_payload:, api_version:)
     api_version = 'v1' if api_version.nil?
+
     presenter = Presenter::Comment.new(form_builder_payload:, api_version:)
 
     Usecase::Optics::CreateCase.new(

--- a/app/jobs/send_comment_job.rb
+++ b/app/jobs/send_comment_job.rb
@@ -1,10 +1,9 @@
 class SendCommentJob < ApplicationJob
   queue_as :send_comments
 
-  def perform(form_builder_payload:)
-    presenter = Presenter::Comment.new(
-      form_builder_payload:
-    )
+  def perform(form_builder_payload:, api_version:)
+    api_version = 'v1' if api_version.nil?
+    presenter = Presenter::Comment.new(form_builder_payload:, api_version:)
 
     Usecase::Optics::CreateCase.new(
       optics_gateway: gateway,

--- a/app/jobs/send_complaint_job.rb
+++ b/app/jobs/send_complaint_job.rb
@@ -2,7 +2,7 @@ class SendComplaintJob < ApplicationJob
   queue_as :send_complaints
 
   # rubocop:disable Metrics/MethodLength
-  def perform(form_builder_payload:, api_version: 'v1')
+  def perform(form_builder_payload:, api_version:)
     api_version = 'v1' if api_version.nil?
     Rails.logger.warn("Working on job_id: #{job_id}")
 

--- a/app/jobs/send_complaint_job.rb
+++ b/app/jobs/send_complaint_job.rb
@@ -2,7 +2,9 @@ class SendComplaintJob < ApplicationJob
   queue_as :send_complaints
 
   # rubocop:disable Metrics/MethodLength
-  def perform(form_builder_payload:)
+  def perform(form_builder_payload:, api_version: 'v1')
+    api_version = 'v1' if api_version.nil?
+
     Rails.logger.info("Working on job_id: #{job_id}")
 
     attachments = Usecase::SpawnAttachments.new(
@@ -10,7 +12,8 @@ class SendComplaintJob < ApplicationJob
     ).call
     presenter = Presenter::Complaint.new(
       form_builder_payload:,
-      attachments:
+      attachments:,
+      api_version:
     )
 
     Usecase::Optics::CreateCase.new(

--- a/app/jobs/send_complaint_job.rb
+++ b/app/jobs/send_complaint_job.rb
@@ -4,7 +4,7 @@ class SendComplaintJob < ApplicationJob
   # rubocop:disable Metrics/MethodLength
   def perform(form_builder_payload:, api_version:)
     api_version = 'v1' if api_version.nil?
-    Rails.logger.warn("Working on job_id: #{job_id}")
+    Rails.logger.info("Working on job_id: #{job_id}")
 
     attachments = Usecase::SpawnAttachments.new(
       form_builder_payload:
@@ -21,7 +21,7 @@ class SendComplaintJob < ApplicationJob
       get_bearer_token: bearer_token
     ).execute
 
-    Rails.logger.warn("Sent #{form_builder_payload[:submissionId]} to Optics")
+    Rails.logger.info("Sent #{form_builder_payload[:submissionId]} to Optics")
 
     record_successful_submission(form_builder_payload[:submissionId])
   end

--- a/app/jobs/send_complaint_job.rb
+++ b/app/jobs/send_complaint_job.rb
@@ -4,8 +4,7 @@ class SendComplaintJob < ApplicationJob
   # rubocop:disable Metrics/MethodLength
   def perform(form_builder_payload:, api_version: 'v1')
     api_version = 'v1' if api_version.nil?
-
-    Rails.logger.info("Working on job_id: #{job_id}")
+    Rails.logger.warn("Working on job_id: #{job_id}")
 
     attachments = Usecase::SpawnAttachments.new(
       form_builder_payload:
@@ -21,6 +20,8 @@ class SendComplaintJob < ApplicationJob
       presenter:,
       get_bearer_token: bearer_token
     ).execute
+
+    Rails.logger.warn("Sent #{form_builder_payload[:submissionId]} to Optics")
 
     record_successful_submission(form_builder_payload[:submissionId])
   end

--- a/app/jobs/send_feedback_job.rb
+++ b/app/jobs/send_feedback_job.rb
@@ -1,7 +1,10 @@
 class SendFeedbackJob < ApplicationJob
   queue_as :send_feedback
 
-  def perform(form_builder_payload:, api_version: 'v1')
+  # rubocop:disable Metrics/MethodLength
+  def perform(form_builder_payload:, api_version:)
+    api_version = 'v1' if api_version.nil?
+
     presenter = Presenter::Feedback.new(
       form_builder_payload:,
       api_version:
@@ -15,4 +18,5 @@ class SendFeedbackJob < ApplicationJob
 
     record_successful_submission(form_builder_payload[:submissionId])
   end
+  # rubocop:enable Metrics/MethodLength
 end

--- a/app/jobs/send_feedback_job.rb
+++ b/app/jobs/send_feedback_job.rb
@@ -1,14 +1,10 @@
 class SendFeedbackJob < ApplicationJob
   queue_as :send_feedback
 
-  # rubocop:disable Metrics/MethodLength
   def perform(form_builder_payload:, api_version:)
     api_version = 'v1' if api_version.nil?
 
-    presenter = Presenter::Feedback.new(
-      form_builder_payload:,
-      api_version:
-    )
+    presenter = Presenter::Feedback.new(form_builder_payload:, api_version:)
 
     Usecase::Optics::CreateCase.new(
       optics_gateway: gateway,
@@ -18,5 +14,4 @@ class SendFeedbackJob < ApplicationJob
 
     record_successful_submission(form_builder_payload[:submissionId])
   end
-  # rubocop:enable Metrics/MethodLength
 end

--- a/app/jobs/send_feedback_job.rb
+++ b/app/jobs/send_feedback_job.rb
@@ -1,9 +1,10 @@
 class SendFeedbackJob < ApplicationJob
   queue_as :send_feedback
 
-  def perform(form_builder_payload:)
+  def perform(form_builder_payload:, api_version: 'v1')
     presenter = Presenter::Feedback.new(
-      form_builder_payload:
+      form_builder_payload:,
+      api_version:
     )
 
     Usecase::Optics::CreateCase.new(

--- a/app/lib/presenter/base_presenter.rb
+++ b/app/lib/presenter/base_presenter.rb
@@ -16,13 +16,5 @@ module Presenter
       time = submission_answers.fetch(:submissionDate, (Time.now.to_i * 1000).to_s)
       Time.at(time.to_s.to_i / 1000).strftime(format)
     end
-
-    def format_date_optics(date)
-      Date.parse(date).to_s
-    end
-
-    def format_phone_number_optics(phone_string)
-      phone_string.to_i
-    end
   end
 end

--- a/app/lib/presenter/base_presenter.rb
+++ b/app/lib/presenter/base_presenter.rb
@@ -1,7 +1,8 @@
 module Presenter
   class BasePresenter
-    def initialize(form_builder_payload:)
+    def initialize(form_builder_payload:, api_version: 'v1')
       @form_builder_payload = form_builder_payload
+      @api_version = api_version
     end
 
     private

--- a/app/lib/presenter/base_presenter.rb
+++ b/app/lib/presenter/base_presenter.rb
@@ -16,5 +16,9 @@ module Presenter
       time = submission_answers.fetch(:submissionDate, (Time.now.to_i * 1000).to_s)
       Time.at(time.to_s.to_i / 1000).strftime(format)
     end
+
+    def format_date_optics(date)
+      Date.parse(date).to_s
+    end
   end
 end

--- a/app/lib/presenter/base_presenter.rb
+++ b/app/lib/presenter/base_presenter.rb
@@ -20,5 +20,9 @@ module Presenter
     def format_date_optics(date)
       Date.parse(date).to_s
     end
+
+    def format_phone_number_optics(phone_string)
+      phone_string.to_i
+    end
   end
 end

--- a/app/lib/presenter/comment.rb
+++ b/app/lib/presenter/comment.rb
@@ -5,16 +5,7 @@ module Presenter
     # rubocop:disable Metrics/MethodLength, Naming/VariableNumber
     def optics_payload
       service_slug = form_builder_payload.fetch(:serviceSlug)
-      if service_slug.include? 'hmcts-comments-form'
-        {
-          Type: type,
-          RequestDate: request_date,
-          RequestMethod: REQUEST_METHOD,
-          AssignedTeam: submission_answers.fetch(:'which-contact-with_autocomplete_1', ''),
-          'Case.ServiceTeam': submission_answers.fetch(:'which-contact-with_autocomplete_1', ''),
-          Details: submission_answers.fetch(:feedback_textarea_1, '')
-        }
-      else
+      if service_slug == 'comments-form'
         {
           Type: type,
           RequestDate: request_date,
@@ -22,6 +13,15 @@ module Presenter
           AssignedTeam: submission_answers.fetch(:contact_location, ''),
           'Case.ServiceTeam': submission_answers.fetch(:contact_location, ''),
           Details: submission_answers.fetch(:feedback_details, '')
+        }
+      else
+        {
+          Type: type,
+          RequestDate: request_date,
+          RequestMethod: REQUEST_METHOD,
+          AssignedTeam: submission_answers.fetch(:'which-contact-with_autocomplete_1', ''),
+          'Case.ServiceTeam': submission_answers.fetch(:'which-contact-with_autocomplete_1', ''),
+          Details: submission_answers.fetch(:feedback_textarea_1, '')
         }
       end
     end

--- a/app/lib/presenter/comment.rb
+++ b/app/lib/presenter/comment.rb
@@ -5,6 +5,7 @@ module Presenter
     # rubocop:disable Metrics/MethodLength, Naming/VariableNumber
     def optics_payload
       service_slug = form_builder_payload.fetch(:serviceSlug)
+      # Handling legacy form
       if service_slug == 'comments-form'
         {
           Type: type,

--- a/app/lib/presenter/comment.rb
+++ b/app/lib/presenter/comment.rb
@@ -4,9 +4,8 @@ module Presenter
 
     # rubocop:disable Metrics/MethodLength, Naming/VariableNumber
     def optics_payload
-      service_slug = form_builder_payload.fetch(:serviceSlug)
-      # Handling legacy form
-      if service_slug == 'comments-form'
+      case @api_version
+      when 'v1'
         {
           Type: type,
           RequestDate: request_date,
@@ -15,7 +14,7 @@ module Presenter
           'Case.ServiceTeam': submission_answers.fetch(:contact_location, ''),
           Details: submission_answers.fetch(:feedback_details, '')
         }
-      else
+      when 'v2'
         {
           Type: type,
           RequestDate: request_date,

--- a/app/lib/presenter/comment.rb
+++ b/app/lib/presenter/comment.rb
@@ -2,16 +2,30 @@ module Presenter
   class Comment < BasePresenter
     REQUEST_METHOD = 'Online form'.freeze
 
+    # rubocop:disable Metrics/MethodLength, Naming/VariableNumber
     def optics_payload
-      {
-        Type: type,
-        RequestDate: request_date,
-        RequestMethod: REQUEST_METHOD,
-        AssignedTeam: submission_answers.fetch(:contact_location, ''),
-        'Case.ServiceTeam': submission_answers.fetch(:contact_location, ''),
-        Details: submission_answers.fetch(:feedback_details, '')
-      }
+      service_slug = form_builder_payload.fetch(:serviceSlug)
+      if service_slug.include? 'hmcts-comments-form'
+        {
+          Type: type,
+          RequestDate: request_date,
+          RequestMethod: REQUEST_METHOD,
+          AssignedTeam: submission_answers.fetch(:'which-contact-with_autocomplete_1', ''),
+          'Case.ServiceTeam': submission_answers.fetch(:'which-contact-with_autocomplete_1', ''),
+          Details: submission_answers.fetch(:feedback_textarea_1, '')
+        }
+      else
+        {
+          Type: type,
+          RequestDate: request_date,
+          RequestMethod: REQUEST_METHOD,
+          AssignedTeam: submission_answers.fetch(:contact_location, ''),
+          'Case.ServiceTeam': submission_answers.fetch(:contact_location, ''),
+          Details: submission_answers.fetch(:feedback_details, '')
+        }
+      end
     end
+    # rubocop:enable Metrics/MethodLength, Naming/VariableNumber
 
     private
 

--- a/app/lib/presenter/complaint.rb
+++ b/app/lib/presenter/complaint.rb
@@ -1,16 +1,14 @@
 module Presenter
   class Complaint < BasePresenter
-    def initialize(form_builder_payload:, attachments:)
-      super(form_builder_payload:)
+    def initialize(form_builder_payload:, attachments:, api_version:)
+      super(form_builder_payload:, api_version:)
       @attachments = attachments
     end
 
     # rubocop:disable Metrics/MethodLength,
     def optics_payload
-      service_slug = form_builder_payload.fetch(:serviceSlug)
-
-      # If this submission comes from legacy form
-      if service_slug == 'complain-about-a-court-or-tribunal'
+      case @api_version
+      when 'v1'
         {
           Team: submission_answers.fetch(:complaint_location),
           AssignedTeam: submission_answers.fetch(:complaint_location),
@@ -19,7 +17,7 @@ module Presenter
           Details: submission_answers.fetch(:complaint_details, ''),
           Reference: submission_answers.fetch(:case_number, '')
         }.merge(constant_data, customer_data, *attachments_data)
-      else
+      when 'v2'
         {
           # rubocop:disable Naming/VariableNumber
           Team: submission_answers.fetch(:courtortribunalyourcomplaintisabout_autocomplete_1),

--- a/app/lib/presenter/complaint.rb
+++ b/app/lib/presenter/complaint.rb
@@ -7,8 +7,6 @@ module Presenter
 
     # rubocop:disable Metrics/MethodLength,
     def optics_payload
-      Rails.logger.warn("api version: #{@api_version}")
-
       case @api_version
       when 'v1'
         {

--- a/app/lib/presenter/complaint.rb
+++ b/app/lib/presenter/complaint.rb
@@ -7,6 +7,8 @@ module Presenter
 
     # rubocop:disable Metrics/MethodLength,
     def optics_payload
+      Rails.logger.warn("api version: #{@api_version}")
+
       case @api_version
       when 'v1'
         {

--- a/app/lib/presenter/complaint.rb
+++ b/app/lib/presenter/complaint.rb
@@ -5,16 +5,34 @@ module Presenter
       @attachments = attachments
     end
 
+    # rubocop:disable Metrics/MethodLength,
     def optics_payload
-      {
-        Team: submission_answers.fetch(:complaint_location),
-        AssignedTeam: submission_answers.fetch(:complaint_location),
-        AssignedTeamSS: submission_answers.fetch(:complaint_location),
-        RequestDate: request_date,
-        Details: submission_answers.fetch(:complaint_details, ''),
-        Reference: submission_answers.fetch(:case_number, '')
-      }.merge(constant_data, customer_data, *attachments_data)
+      service_slug = form_builder_payload.fetch(:serviceSlug)
+
+      # If this submission comes from legacy form
+      if service_slug == 'complain-about-a-court-or-tribunal'
+        {
+          Team: submission_answers.fetch(:complaint_location),
+          AssignedTeam: submission_answers.fetch(:complaint_location),
+          AssignedTeamSS: submission_answers.fetch(:complaint_location),
+          RequestDate: request_date,
+          Details: submission_answers.fetch(:complaint_details, ''),
+          Reference: submission_answers.fetch(:case_number, '')
+        }.merge(constant_data, customer_data, *attachments_data)
+      else
+        {
+          # rubocop:disable Naming/VariableNumber
+          Team: submission_answers.fetch(:courtortribunalyourcomplaintisabout_autocomplete_1),
+          AssignedTeam: submission_answers.fetch(:courtortribunalyourcomplaintisabout_autocomplete_1),
+          AssignedTeamSS: submission_answers.fetch(:courtortribunalyourcomplaintisabout_autocomplete_1),
+          RequestDate: request_date,
+          Details: submission_answers.fetch(:yourcomplaint_textarea_1, ''),
+          Reference: submission_answers.fetch(:casenumber_text_1, '')
+        }.merge(constant_data, customer_data_v2, *attachments_data)
+        # rubocop:enable Naming/VariableNumber
+      end
     end
+    # rubocop:enable Metrics/MethodLength
 
     private
 
@@ -59,5 +77,22 @@ module Presenter
         'PartyContextManageCases': 'Main'
       }
     end
+
+    # rubocop:disable Metrics/MethodLength, Naming/VariableNumber
+    def customer_data_v2
+      {
+        'Customer.FirstName': submission_answers.fetch(:yourname_text_1, ''),
+        'Customer.Surname': submission_answers.fetch(:yourname_text_2, ''),
+        'Customer.Address': '',
+        'Customer.Town': '',
+        'Customer.County': '',
+        'Customer.Postcode': '',
+        'Customer.Email': submission_answers.fetch(:youremailaddress_email_1, ''),
+        'Customer.Phone': '',
+        'Impact': submission_answers.fetch(:howhasthisaffectedyou_textarea_1, ''),
+        'ActionRequested': submission_answers.fetch(:whatcanwedotoputthisright_textarea_1, '')
+      }
+    end
+    # rubocop:enable Metrics/MethodLength, Naming/VariableNumber
   end
 end

--- a/app/lib/presenter/complaint.rb
+++ b/app/lib/presenter/complaint.rb
@@ -30,7 +30,7 @@ module Presenter
         'Customer.County': submission_answers.fetch(:county, ''),
         'Customer.Postcode': submission_answers.fetch(:postcode, ''),
         'Customer.Email': submission_answers.fetch(:email_address, ''),
-        'Customer.Phone': submission_answers.fetch(:phone, ''),
+        'Customer.Phone': format_phone_number_optics(submission_answers.fetch(:phone, '')),
         'Impact': submission_answers.fetch(:impact, ''),
         'ActionRequested': submission_answers.fetch(:action_requested, '')
       }

--- a/app/lib/presenter/complaint.rb
+++ b/app/lib/presenter/complaint.rb
@@ -30,7 +30,7 @@ module Presenter
         'Customer.County': submission_answers.fetch(:county, ''),
         'Customer.Postcode': submission_answers.fetch(:postcode, ''),
         'Customer.Email': submission_answers.fetch(:email_address, ''),
-        'Customer.Phone': format_phone_number_optics(submission_answers.fetch(:phone, '')),
+        'Customer.Phone': submission_answers.fetch(:phone, ''),
         'Impact': submission_answers.fetch(:impact, ''),
         'ActionRequested': submission_answers.fetch(:action_requested, '')
       }

--- a/app/lib/presenter/correspondence.rb
+++ b/app/lib/presenter/correspondence.rb
@@ -56,7 +56,7 @@ module Presenter
         'Agent.Forename1': submission_answers.fetch(:ApplicantFirstName, ''),
         'Agent.Name': submission_answers.fetch(:ApplicantLastName, ''),
         'Agent.Email': submission_answers.fetch(:ApplicantEmail, ''),
-        'Agent.Phone': format_phone_number_optics(submission_answers.fetch(:ApplicantPhone, ''))
+        'Agent.Phone': submission_answers.fetch(:ApplicantPhone, '')
       }
     end
 
@@ -67,7 +67,7 @@ module Presenter
         'Applicant1.Forename1': submission_answers.fetch(:Applicant1FirstName, ''),
         'Applicant1.Name': submission_answers.fetch(:Applicant1LastName, ''),
         'Applicant1.Email': submission_answers.fetch(:Applicant1Email, ''),
-        'Applicant1.Phone': format_phone_number_optics(submission_answers.fetch(:Applicant1Phone, '')),
+        'Applicant1.Phone': submission_answers.fetch(:Applicant1Phone, ''),
         'Agent.Forename1': '',
         'Agent.Name': '',
         'Agent.Email': '',

--- a/app/lib/presenter/correspondence.rb
+++ b/app/lib/presenter/correspondence.rb
@@ -56,7 +56,7 @@ module Presenter
         'Agent.Forename1': submission_answers.fetch(:ApplicantFirstName, ''),
         'Agent.Name': submission_answers.fetch(:ApplicantLastName, ''),
         'Agent.Email': submission_answers.fetch(:ApplicantEmail, ''),
-        'Agent.Phone': submission_answers.fetch(:ApplicantPhone, '')
+        'Agent.Phone': format_phone_number_optics(submission_answers.fetch(:ApplicantPhone, ''))
       }
     end
 
@@ -67,7 +67,7 @@ module Presenter
         'Applicant1.Forename1': submission_answers.fetch(:Applicant1FirstName, ''),
         'Applicant1.Name': submission_answers.fetch(:Applicant1LastName, ''),
         'Applicant1.Email': submission_answers.fetch(:Applicant1Email, ''),
-        'Applicant1.Phone': submission_answers.fetch(:Applicant1Phone, ''),
+        'Applicant1.Phone': format_phone_number_optics(submission_answers.fetch(:Applicant1Phone, '')),
         'Agent.Forename1': '',
         'Agent.Name': '',
         'Agent.Email': '',

--- a/app/lib/presenter/feedback.rb
+++ b/app/lib/presenter/feedback.rb
@@ -4,17 +4,36 @@ module Presenter
     TYPE = 'UF144908'.freeze
     PARTY_CONTEXT = 'Main'.freeze
 
+    # rubocop:disable Metrics/MethodLength
     def optics_payload
-      {
-        Type: TYPE,
-        RequestDate: request_date,
-        RequestMethod: REQUEST_METHOD,
-        'External.RequestDate': request_date,
-        'External.RequestMethod': REQUEST_METHOD,
-        PartyContext: PARTY_CONTEXT,
-        AssignedTeam: submission_answers.fetch(:contact_location, ''),
-        Details: submission_answers.fetch(:feedback_details, '')
-      }
+      service_slug = form_builder_payload.fetch(:serviceSlug)
+      # If this is the legacy form
+      if service_slug == 'user-feedback'
+        {
+          Type: TYPE,
+          RequestDate: request_date,
+          RequestMethod: REQUEST_METHOD,
+          'External.RequestDate': request_date,
+          'External.RequestMethod': REQUEST_METHOD,
+          PartyContext: PARTY_CONTEXT,
+          AssignedTeam: submission_answers.fetch(:contact_location, ''),
+          Details: submission_answers.fetch(:feedback_details, '')
+        }
+      else
+        {
+          Type: TYPE,
+          RequestDate: request_date,
+          RequestMethod: REQUEST_METHOD,
+          'External.RequestDate': request_date,
+          'External.RequestMethod': REQUEST_METHOD,
+          PartyContext: PARTY_CONTEXT,
+          # rubocop:disable Naming/VariableNumber
+          AssignedTeam: submission_answers.fetch(:whichpartofhmctswereyouincontactwith_autocomplete_1, ''),
+          Details: submission_answers.fetch(:telluswhatwedidwell_textarea_1, '')
+          # rubocop:enable Naming/VariableNumber
+        }
+      end
     end
+    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/app/lib/presenter/feedback.rb
+++ b/app/lib/presenter/feedback.rb
@@ -6,9 +6,7 @@ module Presenter
 
     # rubocop:disable Metrics/MethodLength
     def optics_payload
-      service_slug = form_builder_payload.fetch(:serviceSlug)
-      # If this is the legacy form
-      if service_slug == 'user-feedback'
+      if @api_version == 'v1'
         {
           Type: TYPE,
           RequestDate: request_date,

--- a/app/lib/presenter/feedback.rb
+++ b/app/lib/presenter/feedback.rb
@@ -6,7 +6,8 @@ module Presenter
 
     # rubocop:disable Metrics/MethodLength
     def optics_payload
-      if @api_version == 'v1'
+      case @api_version
+      when 'v1'
         {
           Type: TYPE,
           RequestDate: request_date,
@@ -17,7 +18,7 @@ module Presenter
           AssignedTeam: submission_answers.fetch(:contact_location, ''),
           Details: submission_answers.fetch(:feedback_details, '')
         }
-      else
+      when 'v2'
         {
           Type: TYPE,
           RequestDate: request_date,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,8 +9,9 @@ Rails.application.routes.draw do
   end
 
   scope 'v2' do
-    resources :feedback, only: [:create], defaults: { api_version: 'v2' }
     resources :comment, only: [:create], defaults: { api_version: 'v2' }
+    resources :complaint, only: [:create], defaults: { api_version: 'v2' }
+    resources :feedback, only: [:create], defaults: { api_version: 'v2' }
   end
 
   get '/health', to: 'health#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
 
   scope 'v2' do
     resources :feedback, only: [:create], defaults: { api_version: 'v2' }
+    resources :comment, only: [:create], defaults: { api_version: 'v2' }
   end
 
   get '/health', to: 'health#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,10 @@ Rails.application.routes.draw do
     resources :feedback, only: [:create]
   end
 
+  scope 'v2' do
+    resources :feedback, only: [:create], defaults: { api_version: 'v2' }
+  end
+
   get '/health', to: 'health#show'
   get '/readiness', to: 'health#readiness'
   resource :metrics, only: [:show]

--- a/spec/jobs/send_comment_job_spec.rb
+++ b/spec/jobs/send_comment_job_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe SendCommentJob, type: :job do
       allow(Presenter::Comment)
         .to receive(:new)
         .and_return(presenter)
-        .with(form_builder_payload: input)
+        .with(form_builder_payload: input, api_version: 'v1')
       allow(Usecase::Optics::GenerateJwtToken)
         .to receive(:new).and_return(create_token).with(
           endpoint: Rails.configuration.x.optics.endpoint,
@@ -56,7 +56,7 @@ RSpec.describe SendCommentJob, type: :job do
 
     context 'when the a submission was submitted to Optics' do
       it 'creates a new entry' do
-        jobs.perform(form_builder_payload: input)
+        jobs.perform(form_builder_payload: input, api_version: 'v1')
         expect(ProcessedSubmission.count).to eq(1)
       end
     end

--- a/spec/jobs/send_complaint_job_spec.rb
+++ b/spec/jobs/send_complaint_job_spec.rb
@@ -51,13 +51,13 @@ describe SendComplaintJob, type: :job do
     end
 
     it 'calls the spawn attachments usecase' do
-      jobs.perform(form_builder_payload: input)
+      jobs.perform(form_builder_payload: input, api_version:'v1')
       expect(spawn_attachments).to have_received(:call).once
     end
 
     context 'when the a submission was submitted to Optics' do
       it 'creates a new entry' do
-        jobs.perform(form_builder_payload: input)
+        jobs.perform(form_builder_payload: input, api_version:'v1')
         expect(ProcessedSubmission.count).to eq(1)
       end
     end

--- a/spec/jobs/send_complaint_job_spec.rb
+++ b/spec/jobs/send_complaint_job_spec.rb
@@ -27,7 +27,7 @@ describe SendComplaintJob, type: :job do
     end
 
     before do
-      allow(Presenter::Complaint).to receive(:new).and_return(presenter).with(form_builder_payload: input, attachments: attachments)
+      allow(Presenter::Complaint).to receive(:new).and_return(presenter).with(form_builder_payload: input, attachments: attachments, api_version: 'v1')
       allow(Usecase::Optics::GenerateJwtToken).to receive(:new).and_return(create_token).with(
         endpoint: Rails.configuration.x.optics.endpoint,
         api_key: Rails.configuration.x.optics.api_key,

--- a/spec/jobs/send_feedback_job_spec.rb
+++ b/spec/jobs/send_feedback_job_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe SendFeedbackJob, type: :job do
       allow(Presenter::Feedback)
         .to receive(:new)
         .and_return(presenter)
-        .with(form_builder_payload: input)
+        .with(form_builder_payload: input, api_version:'v1')
       allow(Usecase::Optics::GenerateJwtToken)
         .to receive(:new).and_return(create_token).with(
           endpoint: Rails.configuration.x.optics.endpoint,
@@ -56,7 +56,7 @@ RSpec.describe SendFeedbackJob, type: :job do
 
     context 'when the a submission was submitted to Optics' do
       it 'creates a new entry' do
-        jobs.perform(form_builder_payload: input)
+        jobs.perform(form_builder_payload: input, api_version:'v1')
         expect(ProcessedSubmission.count).to eq(1)
       end
     end

--- a/spec/presenter/comment_spec.rb
+++ b/spec/presenter/comment_spec.rb
@@ -93,5 +93,28 @@ RSpec.describe Presenter::Comment do
         expect(presenter.optics_payload[:RequestDate]).to eq(today)
       end
     end
+
+    context 'moj forms v2' do
+      let(:base_payload) do
+        {
+          serviceSlug: 'hmcts-comments-form-eng',
+          submissionId: 'df58b73f-a8c2-4c2a-90be-da67d3c24136',
+          submissionAnswers:
+          {
+            RequestMethod: Presenter::Comment::REQUEST_METHOD,
+            "which-contact-with_autocomplete_1": 'Champions',
+            feedback_textarea_1: 'this is new information'
+          }
+        }
+        end
+
+        it 'returns the contact location' do
+          expect(presenter.optics_payload[:AssignedTeam]).to eq('Champions')
+        end
+
+        it 'returns the details' do
+          expect(presenter.optics_payload[:Details]).to eq('this is new information')
+        end
+    end
   end
 end

--- a/spec/presenter/comment_spec.rb
+++ b/spec/presenter/comment_spec.rb
@@ -2,99 +2,104 @@ require 'rails_helper'
 
 RSpec.describe Presenter::Comment do
   subject(:presenter) do
-    described_class.new(form_builder_payload: base_payload)
+    described_class.new(form_builder_payload: base_payload, api_version: api_version)
   end
 
   describe '#optics_payload' do
-    let(:base_payload) do
-    {
-      serviceSlug: 'comments-form',
-      submissionId: 'df58b73f-a8c2-4c2a-90be-da67d3c24136',
-      submissionAnswers:
-      {
-        RequestMethod: Presenter::Comment::REQUEST_METHOD,
-        contact_location: '1101',
-        feedback_details: 'some comment with lots of details'
-      }.merge(input_payload)
-    }
-    end
+    context 'v1 legacy Formbuilder' do
+      let(:base_payload) do
+        {
+          serviceSlug: 'comments-form',
+          submissionId: 'df58b73f-a8c2-4c2a-90be-da67d3c24136',
+          submissionAnswers:
+          {
+            RequestMethod: Presenter::Comment::REQUEST_METHOD,
+            contact_location: '1101',
+            feedback_details: 'some comment with lots of details'
+          }.merge(input_payload)
+        }
+      end
 
-    context 'comment type' do
-      context 'when set in the environment' do
-        let(:comment_type) { '1801265' }
+      let(:api_version) { 'v1' }
+
+      context 'comment type' do
+        context 'when set in the environment' do
+          let(:comment_type) { '1801265' }
+          let(:input_payload) do
+            { Type: comment_type }
+          end
+
+          before do
+            allow(ENV).to receive(:[]).with('COMMENT_TYPE').and_return(comment_type)
+          end
+
+          it 'returns "1801265"' do
+            expect(presenter.optics_payload[:Type]).to eq(comment_type)
+          end
+        end
+
+        context 'when comment type is not set' do
+          let(:comment_type) { '' }
+          let(:input_payload) do
+            { Type: comment_type }
+          end
+
+          before do
+            allow(ENV).to receive(:[]).with('COMMENT_TYPE').and_return(comment_type)
+          end
+
+          it 'returns an empty string' do
+            expect(presenter.optics_payload[:Type]).to eq(comment_type)
+          end
+        end
+      end
+
+      context 'request method' do
         let(:input_payload) do
-          { Type: comment_type }
+          {
+            RequestMethod: ''
+          }
         end
-
-        before do
-          allow(ENV).to receive(:[]).with('COMMENT_TYPE').and_return(comment_type)
-        end
-
-        it 'returns "1801265"' do
-          expect(presenter.optics_payload[:Type]).to eq(comment_type)
+        it 'should always return online form' do
+          expect(presenter.optics_payload[:RequestMethod]).to eq('Online form')
         end
       end
 
-      context 'when comment type is not set' do
-        let(:comment_type) { '' }
+      context 'contact location' do
         let(:input_payload) do
-          { Type: comment_type }
+          {
+            contact_location: '2022'
+          }
         end
-
-        before do
-          allow(ENV).to receive(:[]).with('COMMENT_TYPE').and_return(comment_type)
-        end
-
-        it 'returns an empty string' do
-          expect(presenter.optics_payload[:Type]).to eq(comment_type)
+        it 'returns the contact location' do
+          expect(presenter.optics_payload[:AssignedTeam]).to eq('2022')
         end
       end
-    end
 
-    context 'request method' do
-      let(:input_payload) do
-        {
-          RequestMethod: ''
-        }
+      context 'feedback details' do
+        let(:feedback) { 'all the feedback in this message body' }
+        let(:input_payload) do
+          {
+            feedback_details: feedback
+          }
+        end
+        it 'returns the contact location' do
+          expect(presenter.optics_payload[:Details]).to eq(feedback)
+        end
       end
-      it 'should always return online form' do
-        expect(presenter.optics_payload[:RequestMethod]).to eq('Online form')
-      end
-    end
 
-    context 'contact location' do
-      let(:input_payload) do
-        {
-          contact_location: '2022'
-        }
-      end
-      it 'returns the contact location' do
-        expect(presenter.optics_payload[:AssignedTeam]).to eq('2022')
-      end
-    end
+      context 'request rate' do
+        let(:today) { Time.now.strftime('%Y-%m-%d') }
+        let(:input_payload) { {} }
 
-    context 'feedback details' do
-      let(:feedback) { 'all the feedback in this message body' }
-      let(:input_payload) do
-        {
-          feedback_details: feedback
-        }
-      end
-      it 'returns the contact location' do
-        expect(presenter.optics_payload[:Details]).to eq(feedback)
-      end
-    end
-
-    context 'request rate' do
-      let(:today) { Time.now.strftime('%Y-%m-%d') }
-      let(:input_payload) { {} }
-
-      it 'returns a the date correctly formatted' do
-        expect(presenter.optics_payload[:RequestDate]).to eq(today)
+        it 'returns a the date correctly formatted' do
+          expect(presenter.optics_payload[:RequestDate]).to eq(today)
+        end
       end
     end
 
     context 'moj forms v2' do
+      let(:api_version) { 'v2' }
       let(:base_payload) do
         {
           serviceSlug: 'hmcts-comments-form-eng',

--- a/spec/presenter/complaint_spec.rb
+++ b/spec/presenter/complaint_spec.rb
@@ -63,7 +63,7 @@ describe Presenter::Complaint do
       "Customer.County": 'London',
       "Customer.Postcode": 'SW1H 9AJ',
       "Customer.Email": 'test@test.com',
-      "Customer.Phone": 07548733456,
+      "Customer.Phone": '07548733456',
       Details: 'I lost my case',
       Impact: 'I felt sad',
       ActionRequested: 'Reimbursement',

--- a/spec/presenter/complaint_spec.rb
+++ b/spec/presenter/complaint_spec.rb
@@ -63,7 +63,7 @@ describe Presenter::Complaint do
       "Customer.County": 'London',
       "Customer.Postcode": 'SW1H 9AJ',
       "Customer.Email": 'test@test.com',
-      "Customer.Phone": '07548733456',
+      "Customer.Phone": 07548733456,
       Details: 'I lost my case',
       Impact: 'I felt sad',
       ActionRequested: 'Reimbursement',

--- a/spec/presenter/complaint_spec.rb
+++ b/spec/presenter/complaint_spec.rb
@@ -8,7 +8,7 @@ describe Presenter::Complaint do
 
   let(:input_payload) do
     {
-      'serviceSlug': 'my-form',
+      'serviceSlug': 'complain-about-a-court-or-tribunal',
       'submissionId': '1e937616-dd0b-4bc3-8c67-40e4ffd54f78',
       'submissionAnswers': {
         'first_name': 'Jim',
@@ -91,7 +91,7 @@ describe Presenter::Complaint do
 
     let(:invalid_input_payload) do
       {
-        'serviceSlug': 'my-form',
+        'serviceSlug': 'complain-about-a-court-or-tribunal',
         'submissionId': '1e937616-dd0b-4bc3-8c67-40e4ffd54f78',
         'submissionAnswers': {
           'complaint_location': '1001'
@@ -127,6 +127,64 @@ describe Presenter::Complaint do
 
     it 'still returns a hash without failures' do
       expect(presenter.optics_payload).to eq(output)
+    end
+  end
+
+  context 'v2 mojforms' do
+    let(:input_payload) do
+      {
+        'serviceSlug': 'hmcts-complaint-form-eng',
+        'submissionId': '2c5d9b9e-241b-4cc4-b281-f6a524484df9',
+        'submissionAnswers': {
+          'yourname_text_1': 'First',
+          'yourname_text_2': 'Last',
+          'casenumber_text_1': '123456',
+          'youremailaddress_email_1': 'first.last@test.com',
+          'yourcomplaint_textarea_1': 'Life is unfair',
+          'howhasthisaffectedyou_textarea_1': 'This is sad',
+          'whatcanwedotoputthisright_textarea_1': 'Consolation',
+          'courtortribunalyourcomplaintisabout_autocomplete_1': '1002',
+          'submissionDate': '1568199892316'
+        }
+      }
+    end
+
+    let(:output_v2) do
+      {
+        db: 'hmcts',
+        Type: 'Complaint',
+        Format: 'json',
+        Team: '1002',
+        AssignedTeam: '1002',
+        AssignedTeamSS: '1002',
+        RequestDate: '2019-09-11',
+        Reference: '123456',
+        "PartyContextManageCases": 'Main',
+        "Customer.FirstName": 'First',
+        "Customer.Surname": 'Last',
+        "Customer.Address": '',
+        "Customer.Town": '',
+        "Customer.County": '',
+        "Customer.Postcode": '',
+        "Customer.Email": 'first.last@test.com',
+        "Customer.Phone": '',
+        Details: 'Life is unfair',
+        Impact: 'This is sad',
+        ActionRequested: 'Consolation',
+        RequestMethod: 'Online - gov.uk',
+        "Document1.Name": 'image.png',
+        "Document1.URL": 'https://example.com/v1/attachments/3c535282-6ebb-41c5-807e-74394ef036b1',
+        "Document1.MimeType": 'image/png',
+        "Document1.URLLoadContent": true,
+        "Document2.Name": 'document.pdf',
+        "Document2.URL": 'https://example.com/v1/attachments/3c535282-6ebb-41c5-807e-74394ef036b2',
+        "Document2.MimeType": 'application/pdf',
+        "Document2.URLLoadContent": true
+      }
+    end
+
+    it 'generates the correct hash' do
+      expect(presenter.optics_payload).to eq(output_v2)
     end
   end
 end

--- a/spec/presenter/complaint_spec.rb
+++ b/spec/presenter/complaint_spec.rb
@@ -3,31 +3,8 @@ require 'rails_helper'
 describe Presenter::Complaint do
   subject(:presenter) do
     described_class.new(form_builder_payload: input_payload,
-                        attachments: attachments)
-  end
-
-  let(:input_payload) do
-    {
-      'serviceSlug': 'complain-about-a-court-or-tribunal',
-      'submissionId': '1e937616-dd0b-4bc3-8c67-40e4ffd54f78',
-      'submissionAnswers': {
-        'first_name': 'Jim',
-        'last_name': 'Complainer',
-        'email_address': 'test@test.com',
-        'phone': '07548733456',
-        'building_street': '102 Petty France',
-        'building_street_line2': 'Westminster',
-        'town_city': 'London',
-        'county': 'London',
-        'postcode': 'SW1H 9AJ',
-        'complaint_details': 'I lost my case',
-        'impact': 'I felt sad',
-        'action_requested': 'Reimbursement',
-        'complaint_location': '1001',
-        'submissionDate': '1568199892316',
-        'case_number': '12345'
-      }
-    }
+                        attachments: attachments,
+                        api_version: api_version)
   end
 
   let(:attachments) do
@@ -45,56 +22,29 @@ describe Presenter::Complaint do
     ]
   end
 
-  let(:output) do
-    {
-      db: 'hmcts',
-      Type: 'Complaint',
-      Format: 'json',
-      Team: '1001',
-      AssignedTeam: '1001',
-      AssignedTeamSS: '1001',
-      RequestDate: '2019-09-11',
-      Reference: '12345',
-      "PartyContextManageCases": 'Main',
-      "Customer.FirstName": 'Jim',
-      "Customer.Surname": 'Complainer',
-      "Customer.Address": '102 Petty France',
-      "Customer.Town": 'London',
-      "Customer.County": 'London',
-      "Customer.Postcode": 'SW1H 9AJ',
-      "Customer.Email": 'test@test.com',
-      "Customer.Phone": '07548733456',
-      Details: 'I lost my case',
-      Impact: 'I felt sad',
-      ActionRequested: 'Reimbursement',
-      RequestMethod: 'Online - gov.uk',
-      "Document1.Name": 'image.png',
-      "Document1.URL": 'https://example.com/v1/attachments/3c535282-6ebb-41c5-807e-74394ef036b1',
-      "Document1.MimeType": 'image/png',
-      "Document1.URLLoadContent": true,
-      "Document2.Name": 'document.pdf',
-      "Document2.URL": 'https://example.com/v1/attachments/3c535282-6ebb-41c5-807e-74394ef036b2',
-      "Document2.MimeType": 'application/pdf',
-      "Document2.URLLoadContent": true
-    }
-  end
+  context 'legacy v1 formbuilder submissions' do
+    let(:api_version) {'v1'}
 
-  it 'generates the correct hash' do
-    expect(presenter.optics_payload).to eq(output)
-  end
-
-  context 'with missing data' do
-    subject(:presenter) do
-      described_class.new(form_builder_payload: invalid_input_payload,
-                          attachments: [])
-    end
-
-    let(:invalid_input_payload) do
+    let(:input_payload) do
       {
         'serviceSlug': 'complain-about-a-court-or-tribunal',
         'submissionId': '1e937616-dd0b-4bc3-8c67-40e4ffd54f78',
         'submissionAnswers': {
-          'complaint_location': '1001'
+          'first_name': 'Jim',
+          'last_name': 'Complainer',
+          'email_address': 'test@test.com',
+          'phone': '07548733456',
+          'building_street': '102 Petty France',
+          'building_street_line2': 'Westminster',
+          'town_city': 'London',
+          'county': 'London',
+          'postcode': 'SW1H 9AJ',
+          'complaint_details': 'I lost my case',
+          'impact': 'I felt sad',
+          'action_requested': 'Reimbursement',
+          'complaint_location': '1001',
+          'submissionDate': '1568199892316',
+          'case_number': '12345'
         }
       }
     end
@@ -104,33 +54,91 @@ describe Presenter::Complaint do
         db: 'hmcts',
         Type: 'Complaint',
         Format: 'json',
-        Reference: '',
-        RequestMethod: 'Online - gov.uk',
-        "PartyContextManageCases": 'Main',
-        RequestDate: Date.today.to_s,
         Team: '1001',
         AssignedTeam: '1001',
         AssignedTeamSS: '1001',
-        "Customer.FirstName": '',
-        "Customer.Surname": '',
-        "Customer.Address": '',
-        "Customer.Town": '',
-        "Customer.County": '',
-        "Customer.Postcode": '',
-        "Customer.Email": '',
-        "Customer.Phone": '',
-        Details: '',
-        Impact: '',
-        ActionRequested: ''
+        RequestDate: '2019-09-11',
+        Reference: '12345',
+        "PartyContextManageCases": 'Main',
+        "Customer.FirstName": 'Jim',
+        "Customer.Surname": 'Complainer',
+        "Customer.Address": '102 Petty France',
+        "Customer.Town": 'London',
+        "Customer.County": 'London',
+        "Customer.Postcode": 'SW1H 9AJ',
+        "Customer.Email": 'test@test.com',
+        "Customer.Phone": '07548733456',
+        Details: 'I lost my case',
+        Impact: 'I felt sad',
+        ActionRequested: 'Reimbursement',
+        RequestMethod: 'Online - gov.uk',
+        "Document1.Name": 'image.png',
+        "Document1.URL": 'https://example.com/v1/attachments/3c535282-6ebb-41c5-807e-74394ef036b1',
+        "Document1.MimeType": 'image/png',
+        "Document1.URLLoadContent": true,
+        "Document2.Name": 'document.pdf',
+        "Document2.URL": 'https://example.com/v1/attachments/3c535282-6ebb-41c5-807e-74394ef036b2',
+        "Document2.MimeType": 'application/pdf',
+        "Document2.URLLoadContent": true
       }
     end
 
-    it 'still returns a hash without failures' do
+    it 'generates the correct hash' do
       expect(presenter.optics_payload).to eq(output)
+    end
+
+    context 'with missing data' do
+      subject(:presenter) do
+        described_class.new(form_builder_payload: invalid_input_payload,
+                            attachments: [],
+                            api_version: api_version)
+      end
+
+      let(:invalid_input_payload) do
+        {
+          'serviceSlug': 'complain-about-a-court-or-tribunal',
+          'submissionId': '1e937616-dd0b-4bc3-8c67-40e4ffd54f78',
+          'submissionAnswers': {
+            'complaint_location': '1001'
+          }
+        }
+      end
+
+      let(:output) do
+        {
+          db: 'hmcts',
+          Type: 'Complaint',
+          Format: 'json',
+          Reference: '',
+          RequestMethod: 'Online - gov.uk',
+          "PartyContextManageCases": 'Main',
+          RequestDate: Date.today.to_s,
+          Team: '1001',
+          AssignedTeam: '1001',
+          AssignedTeamSS: '1001',
+          "Customer.FirstName": '',
+          "Customer.Surname": '',
+          "Customer.Address": '',
+          "Customer.Town": '',
+          "Customer.County": '',
+          "Customer.Postcode": '',
+          "Customer.Email": '',
+          "Customer.Phone": '',
+          Details: '',
+          Impact: '',
+          ActionRequested: ''
+        }
+      end
+
+      it 'still returns a hash without failures' do
+        expect(presenter.optics_payload).to eq(output)
+      end
     end
   end
 
   context 'v2 mojforms' do
+    let(:api_version) {'v2'}
+
     let(:input_payload) do
       {
         'serviceSlug': 'hmcts-complaint-form-eng',

--- a/spec/presenter/correspondence_spec.rb
+++ b/spec/presenter/correspondence_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe Presenter::Correspondence do
           'Applicant1.Forename1': 'Qui Gon',
           'Applicant1.Name': 'Jinn',
           'Applicant1.Email': 'quigon@jedi-temple.com',
-          'Applicant1.Phone': 5555555555,
+          'Applicant1.Phone': '5555555555',
           'Case.ReceivedDate': today,
           'CaseContactPostcode.Subject': '',
           'CaseContactCustom17.Representative': '',
@@ -332,7 +332,7 @@ RSpec.describe Presenter::Correspondence do
           'Agent.Forename1': 'Qui Gon',
           'Agent.Name': 'Jinn',
           'Agent.Email': 'quigon@jedi-temple.com',
-          'Agent.Phone': 5555555555
+          'Agent.Phone': '5555555555'
         }.merge(constant_data)
       end
 

--- a/spec/presenter/correspondence_spec.rb
+++ b/spec/presenter/correspondence_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe Presenter::Correspondence do
           'Applicant1.Forename1': 'Qui Gon',
           'Applicant1.Name': 'Jinn',
           'Applicant1.Email': 'quigon@jedi-temple.com',
-          'Applicant1.Phone': '5555555555',
+          'Applicant1.Phone': 5555555555,
           'Case.ReceivedDate': today,
           'CaseContactPostcode.Subject': '',
           'CaseContactCustom17.Representative': '',
@@ -332,7 +332,7 @@ RSpec.describe Presenter::Correspondence do
           'Agent.Forename1': 'Qui Gon',
           'Agent.Name': 'Jinn',
           'Agent.Email': 'quigon@jedi-temple.com',
-          'Agent.Phone': '5555555555'
+          'Agent.Phone': 5555555555
         }.merge(constant_data)
       end
 

--- a/spec/presenter/feedback_spec.rb
+++ b/spec/presenter/feedback_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Presenter::Feedback do
   subject(:presenter) do
-    described_class.new(form_builder_payload: base_payload, api_version:)
+    described_class.new(form_builder_payload: base_payload, api_version: api_version)
   end
 
   describe '#optics_payload' do

--- a/spec/presenter/feedback_spec.rb
+++ b/spec/presenter/feedback_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Presenter::Feedback do
   describe '#optics_payload' do
     let(:base_payload) do
     {
-      serviceSlug: 'user-feedback-form',
+      serviceSlug: 'user-feedback',
       submissionId: 'd2f3829d-2496-463e-8d0a-e86e354e225a',
       submissionAnswers:
       {
@@ -100,6 +100,30 @@ RSpec.describe Presenter::Feedback do
       end
       it 'should always return Main' do
         expect(presenter.optics_payload[:PartyContext]).to eq(Presenter::Feedback::PARTY_CONTEXT)
+      end
+    end
+
+    context 'v2 moj-forms inputs' do
+      let(:base_payload) do
+        {
+          serviceSlug: 'hmcts-feedback-form-eng',
+          submissionId: '72c49803-e9c3-42ac-bde1-09c04595a2d3',
+          submissionAnswers:
+          {
+            RequestMethod: Presenter::Feedback::REQUEST_METHOD,
+            'External.RequestMethod': Presenter::Feedback::REQUEST_METHOD,
+            whichpartofhmctswereyouincontactwith_autocomplete_1: '107',
+            telluswhatwedidwell_textarea_1: 'Thank you very much'
+          }
+        }
+      end
+
+      it 'returns the hmcts team' do
+        expect(presenter.optics_payload[:AssignedTeam]).to eq('107')
+      end
+
+      it 'returns the details of feedback' do
+        expect(presenter.optics_payload[:Details]).to eq('Thank you very much')
       end
     end
   end

--- a/spec/presenter/feedback_spec.rb
+++ b/spec/presenter/feedback_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Presenter::Feedback do
   subject(:presenter) do
-    described_class.new(form_builder_payload: base_payload)
+    described_class.new(form_builder_payload: base_payload, api_version:)
   end
 
   describe '#optics_payload' do
@@ -19,6 +19,8 @@ RSpec.describe Presenter::Feedback do
       }.merge(input_payload)
     }
     end
+
+    let(:api_version) { 'v1' }
 
     context 'type' do
       let(:input_payload) do
@@ -100,6 +102,7 @@ RSpec.describe Presenter::Feedback do
     end
 
     context 'v2 moj-forms inputs' do
+      let(:api_version) { 'v2' }
       let(:base_payload) do
         {
           serviceSlug: 'hmcts-feedback-form-eng',

--- a/spec/presenter/feedback_spec.rb
+++ b/spec/presenter/feedback_spec.rb
@@ -33,12 +33,8 @@ RSpec.describe Presenter::Feedback do
     end
 
     context 'request method' do
-      let(:input_payload) do
-        {
-          'External.RequestMethod': ''
-        }
-      end
-      
+      let(:input_payload) { { 'External.RequestMethod': '' } }
+
       context 'External.RequestMethod' do
         it 'should always return online form' do
           expect(presenter.optics_payload[:'External.RequestMethod']).to eq('Online form')

--- a/spec/requests/comment_spec.rb
+++ b/spec/requests/comment_spec.rb
@@ -146,14 +146,16 @@ describe 'Submitting a comment', type: :request do
 
       stub_request(:post, "https://uat.icasework.com/createcase?db=hmcts").
       with(
-        body: "{\"Type\":\"\",\"RequestDate\":\"2022-04-25\",\"RequestMethod\":\"Online form\",\"AssignedTeam\":\"\",\"Case.ServiceTeam\":\"\",\"Details\":\"\"}",
+        body: "{\"Type\":\"\",\"RequestDate\":\"2022-04-25\",\"RequestMethod\":\"Online form\",\"AssignedTeam\":\"1111\",\"Case.ServiceTeam\":\"1111\",\"Details\":\"all of the feedback\"}",
         headers: {
         'Accept'=>'*/*',
         'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
         'Authorization'=>'Bearer some_bearer_token',
         'Content-Type'=>'application/json',
         'User-Agent'=>'Ruby'
-        }).to_return(status: 200, body: "", headers: {})
+        }).to_return({  status: 200,
+                        body: 'stub case id response',
+                        headers: {'Content-Type'=>'application/x-www-form-urlencoded'}})
 
       perform_enqueued_jobs do
         post '/v2/comment', params: encrypted_body(msg: runner_submission)
@@ -182,7 +184,7 @@ describe 'Submitting a comment', type: :request do
             'Authorization' => 'Bearer some_bearer_token',
             'Content-Type' => 'application/json'
           },
-          body: '{"Type":"","RequestDate":"2022-04-25","RequestMethod":"Online form","AssignedTeam":"","Case.ServiceTeam":"","Details":""}'
+          body: '{"Type":"","RequestDate":"2022-04-25","RequestMethod":"Online form","AssignedTeam":"1111","Case.ServiceTeam":"1111","Details":"all of the feedback"}'
         ).once
       end
 

--- a/spec/requests/comment_spec.rb
+++ b/spec/requests/comment_spec.rb
@@ -142,8 +142,7 @@ describe 'Submitting a comment', type: :request do
         'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
         'Content-Type'=>'application/x-www-form-urlencoded',
         'User-Agent'=>'Ruby'
-        }).
-      to_return(status: 200, body: "", headers: {})
+        }).to_return(status: 200, body: {access_token: 'some_bearer_token'}.to_json, headers: {})
 
       stub_request(:post, "https://uat.icasework.com/createcase?db=hmcts").
       with(
@@ -154,8 +153,7 @@ describe 'Submitting a comment', type: :request do
         'Authorization'=>'Bearer some_bearer_token',
         'Content-Type'=>'application/json',
         'User-Agent'=>'Ruby'
-        }).
-      to_return(status: 200, body: "", headers: {})
+        }).to_return(status: 200, body: "", headers: {})
 
       perform_enqueued_jobs do
         post '/v2/comment', params: encrypted_body(msg: runner_submission)
@@ -184,7 +182,7 @@ describe 'Submitting a comment', type: :request do
             'Authorization' => 'Bearer some_bearer_token',
             'Content-Type' => 'application/json'
           },
-          body: expected_optics_payload
+          body: '{"Type":"","RequestDate":"2022-04-25","RequestMethod":"Online form","AssignedTeam":"","Case.ServiceTeam":"","Details":""}'
         ).once
       end
 

--- a/spec/requests/comment_spec.rb
+++ b/spec/requests/comment_spec.rb
@@ -50,9 +50,6 @@ describe 'Submitting a comment', type: :request do
           }
         }
       )
-    perform_enqueued_jobs do
-      post '/v1/comment', params: encrypted_body(msg: runner_submission)
-    end
   end
 
   let(:expected_optics_payload) do
@@ -66,53 +63,60 @@ describe 'Submitting a comment', type: :request do
     }.to_json
   end
 
-  let(:runner_submission) do
-    {
-      serviceSlug: 'comments-form',
-      submissionId: '891c837c-adef-4854-8bd0-d681577f381e',
-      submissionAnswers:
+  context 'FormBuilder v1 forms submissions' do
+    before do
+      perform_enqueued_jobs do
+        post '/v1/comment', params: encrypted_body(msg: runner_submission)
+      end
+    end
+    let(:runner_submission) do
       {
-        contact_location: '1111',
-        feedback_details: 'all of the feedback'
-      }
-    }.to_json
-  end
-
-  after do
-    Timecop.return
-  end
-
-  include_context 'when authentication required' do
-    let(:url) { '/v1/comment' }
-  end
-
-  it 'returns 201 on a valid post' do
-    expect(response).to have_http_status(:created)
-  end
-
-  describe 'end to end submission' do
-    it 'requests a bearer token' do
-      expect(WebMock).to have_requested(:post, 'https://uat.icasework.com/token?db=hmcts').with(
-        headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
-        body: 'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzb21lX29wdGljc19hcGlfa2V5IiwiYXVkIjoiaHR0cHM6Ly91YXQuaWNhc2V3b3JrLmNvbS90b2tlbj9kYj1obWN0cyIsImlhdCI6MTY1MDkwMDg4Nn0.zR67gqqkz2PmgafsdBw_qFHWEDLhKsvvD9waJC3hbO8'
-      ).once
+        serviceSlug: 'comments-form',
+        submissionId: '891c837c-adef-4854-8bd0-d681577f381e',
+        submissionAnswers:
+        {
+          contact_location: '1111',
+          feedback_details: 'all of the feedback'
+        }
+      }.to_json
     end
 
-    it 'posts the submission to Optics' do
-      expect(WebMock).to have_requested(:post, 'https://uat.icasework.com/createcase?db=hmcts').with(
-        headers: {
-          'Authorization' => 'Bearer some_bearer_token',
-          'Content-Type' => 'application/json'
-        },
-        body: expected_optics_payload
-      ).once
+    after do
+      Timecop.return
     end
 
-    it 'records that there was a successful submission' do
-      expect(ProcessedSubmission.count).to eq(1)
-      expect(
-        ProcessedSubmission.first.submission_id
-      ).to eq('891c837c-adef-4854-8bd0-d681577f381e')
+    include_context 'when authentication required' do
+      let(:url) { '/v1/comment' }
+    end
+
+    it 'returns 201 on a valid post' do
+      expect(response).to have_http_status(:created)
+    end
+
+    describe 'end to end submission' do
+      it 'requests a bearer token' do
+        expect(WebMock).to have_requested(:post, 'https://uat.icasework.com/token?db=hmcts').with(
+          headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
+          body: 'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzb21lX29wdGljc19hcGlfa2V5IiwiYXVkIjoiaHR0cHM6Ly91YXQuaWNhc2V3b3JrLmNvbS90b2tlbj9kYj1obWN0cyIsImlhdCI6MTY1MDkwMDg4Nn0.zR67gqqkz2PmgafsdBw_qFHWEDLhKsvvD9waJC3hbO8'
+        ).once
+      end
+
+      it 'posts the submission to Optics' do
+        expect(WebMock).to have_requested(:post, 'https://uat.icasework.com/createcase?db=hmcts').with(
+          headers: {
+            'Authorization' => 'Bearer some_bearer_token',
+            'Content-Type' => 'application/json'
+          },
+          body: expected_optics_payload
+        ).once
+      end
+
+      it 'records that there was a successful submission' do
+        expect(ProcessedSubmission.count).to eq(1)
+        expect(
+          ProcessedSubmission.first.submission_id
+        ).to eq('891c837c-adef-4854-8bd0-d681577f381e')
+      end
     end
   end
 end

--- a/spec/requests/complaint_spec.rb
+++ b/spec/requests/complaint_spec.rb
@@ -187,7 +187,7 @@ describe 'Submitting a complaint', type: :request do
         it 'posts the submission to Optics' do
           expect(WebMock).to have_requested(:post, 'https://uat.icasework.com/createcase?db=hmcts').with(
             headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer some_bearer_token', 'Content-Type'=>'application/json', 'User-Agent'=>'Ruby'},
-            body: '{"Team":"111","AssignedTeam":"111","AssignedTeamSS":"111","RequestDate":"2019-09-11","Details":"","Reference":"","db":"hmcts","Type":"Complaint","Format":"json","RequestMethod":"Online - gov.uk","PartyContextManageCases":"Main","Customer.FirstName":"","Customer.Surname":"","Customer.Address":"","Customer.Town":"","Customer.County":"","Customer.Postcode":"","Customer.Email":"","Customer.Phone":"","Impact":"","ActionRequested":"","Document1.Name":"image.png","Document1.MimeType":"image/png","Document1.URL":"https://example.com/v1/attachments/e2161d54-92f8-4e10-b3a1-94630c65df3c","Document1.URLLoadContent":true}'
+            body: expected_optics_payload.to_s
           ).once
         end
 

--- a/spec/requests/complaint_spec.rb
+++ b/spec/requests/complaint_spec.rb
@@ -28,9 +28,6 @@ describe 'Submitting a complaint', type: :request do
         body: 'stub case id response',
         headers: {}
       )
-    perform_enqueued_jobs do
-      post '/v1/complaint', params: encrypted_body(msg: runner_submission)
-    end
   end
 
   let(:expected_optics_payload) do
@@ -63,59 +60,67 @@ describe 'Submitting a complaint', type: :request do
     }.to_json
   end
 
-  let(:runner_submission) do
-    {
-      serviceSlug: 'complain-about-a-court-or-tribunal',
-      submissionId: '891c837c-adef-4854-8bd0-d681577f381e',
-      submissionAnswers:
-      {
-        fullname: 'Full Name',
-        email: 'bob@example.com',
-        is_address_uk: 'yes',
-        'complaint_location': '111'
-      },
-      attachments: [{
-        url: 'https://example.com/s3/image.png',
-        encryption_key: 'secret_key',
-        encryption_iv: 'secret_iv',
-        filename: 'image.png',
-        mimetype: 'image/png'
-      }]
-    }.to_json
-  end
-
   after do
     Timecop.return
   end
 
-  include_context 'when authentication required' do
-    let(:url) { '/v1/complaint' }
-  end
-
-  it 'returns 201 on a valid post' do
-    expect(response).to have_http_status(:created)
-  end
-
-  describe 'end to end submission' do
-    it 'requests a bearer token' do
-      expect(WebMock).to have_requested(:post, 'https://uat.icasework.com/token?db=hmcts').with(
-        headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
-        body: 'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzb21lX29wdGljc19hcGlfa2V5IiwiYXVkIjoiaHR0cHM6Ly91YXQuaWNhc2V3b3JrLmNvbS90b2tlbj9kYj1obWN0cyIsImlhdCI6MTU2ODIxNjA4Nn0.fj8VsMONpeEmeavkh23yRsGAtfVlWkJI267gijpy6pA'
-      ).once
+  context 'v1 formbuilder submission' do
+    before do
+      perform_enqueued_jobs do
+        post '/v1/complaint', params: encrypted_body(msg: runner_submission)
+      end
     end
 
-    it 'posts the submission to Optics' do
-      expect(WebMock).to have_requested(:post, 'https://uat.icasework.com/createcase?db=hmcts').with(
-        headers: { 'Authorization' => 'Bearer some_bearer_token', 'Content-Type' => 'application/json' },
-        body: expected_optics_payload
-      ).once
+    let(:runner_submission) do
+      {
+        serviceSlug: 'complain-about-a-court-or-tribunal',
+        submissionId: '891c837c-adef-4854-8bd0-d681577f381e',
+        submissionAnswers:
+        {
+          fullname: 'Full Name',
+          email: 'bob@example.com',
+          is_address_uk: 'yes',
+          'complaint_location': '111'
+        },
+        attachments: [{
+          url: 'https://example.com/s3/image.png',
+          encryption_key: 'secret_key',
+          encryption_iv: 'secret_iv',
+          filename: 'image.png',
+          mimetype: 'image/png'
+        }]
+      }.to_json
     end
 
-    it 'records that there was a successful submission' do
-      expect(ProcessedSubmission.count).to eq(1)
-      expect(
-        ProcessedSubmission.first.submission_id
-      ).to eq('891c837c-adef-4854-8bd0-d681577f381e')
-    end
+      include_context 'when authentication required' do
+        let(:url) { '/v1/complaint' }
+      end
+
+      it 'returns 201 on a valid post' do
+        expect(response).to have_http_status(:created)
+      end
+
+      describe 'end to end submission' do
+        it 'requests a bearer token' do
+          expect(WebMock).to have_requested(:post, 'https://uat.icasework.com/token?db=hmcts').with(
+            headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
+            body: 'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzb21lX29wdGljc19hcGlfa2V5IiwiYXVkIjoiaHR0cHM6Ly91YXQuaWNhc2V3b3JrLmNvbS90b2tlbj9kYj1obWN0cyIsImlhdCI6MTU2ODIxNjA4Nn0.fj8VsMONpeEmeavkh23yRsGAtfVlWkJI267gijpy6pA'
+          ).once
+        end
+
+        it 'posts the submission to Optics' do
+          expect(WebMock).to have_requested(:post, 'https://uat.icasework.com/createcase?db=hmcts').with(
+            headers: { 'Authorization' => 'Bearer some_bearer_token', 'Content-Type' => 'application/json' },
+            body: expected_optics_payload
+          ).once
+        end
+
+        it 'records that there was a successful submission' do
+          expect(ProcessedSubmission.count).to eq(1)
+          expect(
+            ProcessedSubmission.first.submission_id
+          ).to eq('891c837c-adef-4854-8bd0-d681577f381e')
+        end
+      end
   end
 end

--- a/spec/requests/complaint_spec.rb
+++ b/spec/requests/complaint_spec.rb
@@ -168,23 +168,6 @@ describe 'Submitting a complaint', type: :request do
           }).
         to_return(status: 200, body: "", headers: {})
 
-      # stub_request(:post, 'https://uat.icasework.com/createcase?db=hmcts')
-      #   .with(
-      #     body: expected_optics_payload,
-      #     headers: {
-      #       'Accept'=>'*/*',
-      #       'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-      #       'Authorization' => 'Bearer some_bearer_token',
-      #       'Content-Type' => 'application/json',
-      #       'User-Agent' => 'Ruby'
-      #     }
-      #   )
-      #   .to_return(
-      #     status: 200,
-      #     body: 'stub case id response',
-      #     headers: {}
-      #   )
-
       perform_enqueued_jobs do
         post '/v2/complaint', params: encrypted_body(msg: runner_submission)
       end

--- a/spec/requests/complaint_spec.rb
+++ b/spec/requests/complaint_spec.rb
@@ -125,24 +125,6 @@ describe 'Submitting a complaint', type: :request do
   end
 
   context 'v2 mojforms submissions' do
-    before do
-      stub_request(:post, "https://uat.icasework.com/createcase?db=hmcts").
-        with(
-          body: "{\"Team\":\"111\",\"AssignedTeam\":\"111\",\"AssignedTeamSS\":\"111\",\"RequestDate\":\"2019-09-11\",\"Details\":\"\",\"Reference\":\"\",\"db\":\"hmcts\",\"Type\":\"Complaint\",\"Format\":\"json\",\"RequestMethod\":\"Online - gov.uk\",\"PartyContextManageCases\":\"Main\",\"Customer.FirstName\":\"\",\"Customer.Surname\":\"\",\"Customer.Address\":\"\",\"Customer.Town\":\"\",\"Customer.County\":\"\",\"Customer.Postcode\":\"\",\"Customer.Email\":\"\",\"Customer.Phone\":\"\",\"Impact\":\"\",\"ActionRequested\":\"\",\"Document1.Name\":\"image.png\",\"Document1.MimeType\":\"image/png\",\"Document1.URL\":\"https://example.com/v1/attachments/e2161d54-92f8-4e10-b3a1-94630c65df3c\",\"Document1.URLLoadContent\":true}",
-          headers: {
-        'Accept'=>'*/*',
-        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-        'Authorization'=>'Bearer some_bearer_token',
-        'Content-Type'=>'application/json',
-        'User-Agent'=>'Ruby'
-          }).
-        to_return(status: 200, body: "", headers: {})
-
-      perform_enqueued_jobs do
-        post '/v2/complaint', params: encrypted_body(msg: runner_submission)
-      end
-    end
-
     let(:runner_submission) do
       {
         serviceSlug: 'hmcts-complaint-form-eng',
@@ -168,35 +150,75 @@ describe 'Submitting a complaint', type: :request do
       }.to_json
     end
 
-      include_context 'when authentication required' do
-        let(:url) { '/v2/complaint' }
+    before do
+
+      stub_request(:post, 'https://uat.icasework.com/token?db=hmcts')
+      .with(body: { 'assertion' => 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzb21lX29wdGljc19hcGlfa2V5IiwiYXVkIjoiaHR0cHM6Ly91YXQuaWNhc2V3b3JrLmNvbS90b2tlbj9kYj1obWN0cyIsImlhdCI6MTU2ODIxNjA4Nn0.fj8VsMONpeEmeavkh23yRsGAtfVlWkJI267gijpy6pA', 'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer' },
+            headers: { 'Content-Type' => 'application/x-www-form-urlencoded' }).to_return(status: 200, body: { access_token: 'some_bearer_token' }.to_json, headers: {})
+
+      stub_request(:post, "https://uat.icasework.com/createcase?db=hmcts").
+        with(
+          body: "{\"Team\":\"111\",\"AssignedTeam\":\"111\",\"AssignedTeamSS\":\"111\",\"RequestDate\":\"2019-09-11\",\"Details\":\"\",\"Reference\":\"\",\"db\":\"hmcts\",\"Type\":\"Complaint\",\"Format\":\"json\",\"RequestMethod\":\"Online - gov.uk\",\"PartyContextManageCases\":\"Main\",\"Customer.FirstName\":\"\",\"Customer.Surname\":\"\",\"Customer.Address\":\"\",\"Customer.Town\":\"\",\"Customer.County\":\"\",\"Customer.Postcode\":\"\",\"Customer.Email\":\"\",\"Customer.Phone\":\"\",\"Impact\":\"\",\"ActionRequested\":\"\",\"Document1.Name\":\"image.png\",\"Document1.MimeType\":\"image/png\",\"Document1.URL\":\"https://example.com/v1/attachments/e2161d54-92f8-4e10-b3a1-94630c65df3c\",\"Document1.URLLoadContent\":true}",
+          headers: {
+        'Accept'=>'*/*',
+        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'Authorization'=>'Bearer some_bearer_token',
+        'Content-Type'=>'application/json',
+        'User-Agent'=>'Ruby'
+          }).
+        to_return(status: 200, body: "", headers: {})
+
+      # stub_request(:post, 'https://uat.icasework.com/createcase?db=hmcts')
+      #   .with(
+      #     body: expected_optics_payload,
+      #     headers: {
+      #       'Accept'=>'*/*',
+      #       'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+      #       'Authorization' => 'Bearer some_bearer_token',
+      #       'Content-Type' => 'application/json',
+      #       'User-Agent' => 'Ruby'
+      #     }
+      #   )
+      #   .to_return(
+      #     status: 200,
+      #     body: 'stub case id response',
+      #     headers: {}
+      #   )
+
+      perform_enqueued_jobs do
+        post '/v2/complaint', params: encrypted_body(msg: runner_submission)
+      end
+    end
+
+    include_context 'when authentication required' do
+      let(:url) { '/v2/complaint' }
+    end
+
+    it 'returns 201 on a valid post' do
+      expect(response).to have_http_status(:created)
+    end
+
+    describe 'end to end submission' do
+      it 'requests a bearer token' do
+        expect(WebMock).to have_requested(:post, 'https://uat.icasework.com/token?db=hmcts').with(
+          headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
+          body: 'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzb21lX29wdGljc19hcGlfa2V5IiwiYXVkIjoiaHR0cHM6Ly91YXQuaWNhc2V3b3JrLmNvbS90b2tlbj9kYj1obWN0cyIsImlhdCI6MTU2ODIxNjA4Nn0.fj8VsMONpeEmeavkh23yRsGAtfVlWkJI267gijpy6pA'
+        ).once
       end
 
-      it 'returns 201 on a valid post' do
-        expect(response).to have_http_status(:created)
+      it 'posts the submission to Optics' do
+        expect(WebMock).to have_requested(:post, 'https://uat.icasework.com/createcase?db=hmcts').with(
+          headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer some_bearer_token', 'Content-Type'=>'application/json', 'User-Agent'=>'Ruby'},
+          body: expected_optics_payload.to_s
+        ).once
       end
 
-      describe 'end to end submission' do
-        it 'requests a bearer token' do
-          expect(WebMock).to have_requested(:post, 'https://uat.icasework.com/token?db=hmcts').with(
-            headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
-            body: 'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzb21lX29wdGljc19hcGlfa2V5IiwiYXVkIjoiaHR0cHM6Ly91YXQuaWNhc2V3b3JrLmNvbS90b2tlbj9kYj1obWN0cyIsImlhdCI6MTU2ODIxNjA4Nn0.fj8VsMONpeEmeavkh23yRsGAtfVlWkJI267gijpy6pA'
-          ).once
-        end
-
-        it 'posts the submission to Optics' do
-          expect(WebMock).to have_requested(:post, 'https://uat.icasework.com/createcase?db=hmcts').with(
-            headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer some_bearer_token', 'Content-Type'=>'application/json', 'User-Agent'=>'Ruby'},
-            body: expected_optics_payload.to_s
-          ).once
-        end
-
-        it 'records that there was a successful submission' do
-          expect(ProcessedSubmission.count).to eq(1)
-          expect(
-            ProcessedSubmission.first.submission_id
-          ).to eq('72c49803-e9c3-42ac-bde1-09c04595a2d3')
-        end
+      it 'records that there was a successful submission' do
+        expect(ProcessedSubmission.count).to eq(1)
+        expect(
+          ProcessedSubmission.first.submission_id
+        ).to eq('72c49803-e9c3-42ac-bde1-09c04595a2d3')
       end
+    end
   end
 end

--- a/spec/requests/complaint_spec.rb
+++ b/spec/requests/complaint_spec.rb
@@ -7,27 +7,6 @@ describe 'Submitting a complaint', type: :request do
     Timecop.freeze(Time.parse('2019-09-11 15:34:46 +0000'))
 
     allow(SecureRandom).to receive(:uuid).and_return('e2161d54-92f8-4e10-b3a1-94630c65df3c')
-
-    stub_request(:post, 'https://uat.icasework.com/token?db=hmcts')
-      .with(body: { 'assertion' => 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzb21lX29wdGljc19hcGlfa2V5IiwiYXVkIjoiaHR0cHM6Ly91YXQuaWNhc2V3b3JrLmNvbS90b2tlbj9kYj1obWN0cyIsImlhdCI6MTU2ODIxNjA4Nn0.fj8VsMONpeEmeavkh23yRsGAtfVlWkJI267gijpy6pA', 'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer' },
-            headers: { 'Content-Type' => 'application/x-www-form-urlencoded' }).to_return(status: 200, body: { access_token: 'some_bearer_token' }.to_json, headers: {})
-
-    stub_request(:post, 'https://uat.icasework.com/createcase?db=hmcts')
-      .with(
-        body: expected_optics_payload,
-        headers: {
-          'Accept'=>'*/*',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization' => 'Bearer some_bearer_token',
-          'Content-Type' => 'application/json',
-          'User-Agent' => 'Ruby'
-        }
-      )
-      .to_return(
-        status: 200,
-        body: 'stub case id response',
-        headers: {}
-      )
   end
 
   let(:expected_optics_payload) do
@@ -66,6 +45,27 @@ describe 'Submitting a complaint', type: :request do
 
   context 'v1 formbuilder submission' do
     before do
+      stub_request(:post, 'https://uat.icasework.com/token?db=hmcts')
+      .with(body: { 'assertion' => 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzb21lX29wdGljc19hcGlfa2V5IiwiYXVkIjoiaHR0cHM6Ly91YXQuaWNhc2V3b3JrLmNvbS90b2tlbj9kYj1obWN0cyIsImlhdCI6MTU2ODIxNjA4Nn0.fj8VsMONpeEmeavkh23yRsGAtfVlWkJI267gijpy6pA', 'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer' },
+            headers: { 'Content-Type' => 'application/x-www-form-urlencoded' }).to_return(status: 200, body: { access_token: 'some_bearer_token' }.to_json, headers: {})
+
+    stub_request(:post, 'https://uat.icasework.com/createcase?db=hmcts')
+      .with(
+        body: expected_optics_payload,
+        headers: {
+          'Accept'=>'*/*',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Authorization' => 'Bearer some_bearer_token',
+          'Content-Type' => 'application/json',
+          'User-Agent' => 'Ruby'
+        }
+      )
+      .to_return(
+        status: 200,
+        body: 'stub case id response',
+        headers: {}
+      )
+
       perform_enqueued_jobs do
         post '/v1/complaint', params: encrypted_body(msg: runner_submission)
       end

--- a/spec/requests/complaint_spec.rb
+++ b/spec/requests/complaint_spec.rb
@@ -127,16 +127,16 @@ describe 'Submitting a complaint', type: :request do
   context 'v2 mojforms submissions' do
     before do
       stub_request(:post, "https://uat.icasework.com/createcase?db=hmcts").
-         with(
-           body: "{\"Team\":\"111\",\"AssignedTeam\":\"111\",\"AssignedTeamSS\":\"111\",\"RequestDate\":\"2019-09-11\",\"Details\":\"\",\"Reference\":\"\",\"db\":\"hmcts\",\"Type\":\"Complaint\",\"Format\":\"json\",\"RequestMethod\":\"Online - gov.uk\",\"PartyContextManageCases\":\"Main\",\"Customer.FirstName\":\"\",\"Customer.Surname\":\"\",\"Customer.Address\":\"\",\"Customer.Town\":\"\",\"Customer.County\":\"\",\"Customer.Postcode\":\"\",\"Customer.Email\":\"\",\"Customer.Phone\":\"\",\"Impact\":\"\",\"ActionRequested\":\"\",\"Document1.Name\":\"image.png\",\"Document1.MimeType\":\"image/png\",\"Document1.URL\":\"https://example.com/v1/attachments/e2161d54-92f8-4e10-b3a1-94630c65df3c\",\"Document1.URLLoadContent\":true}",
-           headers: {
-       	  'Accept'=>'*/*',
-       	  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-       	  'Authorization'=>'Bearer some_bearer_token',
-       	  'Content-Type'=>'application/json',
-       	  'User-Agent'=>'Ruby'
-           }).
-         to_return(status: 200, body: "", headers: {})
+        with(
+          body: "{\"Team\":\"111\",\"AssignedTeam\":\"111\",\"AssignedTeamSS\":\"111\",\"RequestDate\":\"2019-09-11\",\"Details\":\"\",\"Reference\":\"\",\"db\":\"hmcts\",\"Type\":\"Complaint\",\"Format\":\"json\",\"RequestMethod\":\"Online - gov.uk\",\"PartyContextManageCases\":\"Main\",\"Customer.FirstName\":\"\",\"Customer.Surname\":\"\",\"Customer.Address\":\"\",\"Customer.Town\":\"\",\"Customer.County\":\"\",\"Customer.Postcode\":\"\",\"Customer.Email\":\"\",\"Customer.Phone\":\"\",\"Impact\":\"\",\"ActionRequested\":\"\",\"Document1.Name\":\"image.png\",\"Document1.MimeType\":\"image/png\",\"Document1.URL\":\"https://example.com/v1/attachments/e2161d54-92f8-4e10-b3a1-94630c65df3c\",\"Document1.URLLoadContent\":true}",
+          headers: {
+        'Accept'=>'*/*',
+        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'Authorization'=>'Bearer some_bearer_token',
+        'Content-Type'=>'application/json',
+        'User-Agent'=>'Ruby'
+          }).
+        to_return(status: 200, body: "", headers: {})
 
       perform_enqueued_jobs do
         post '/v2/complaint', params: encrypted_body(msg: runner_submission)
@@ -174,6 +174,29 @@ describe 'Submitting a complaint', type: :request do
 
       it 'returns 201 on a valid post' do
         expect(response).to have_http_status(:created)
+      end
+
+      describe 'end to end submission' do
+        it 'requests a bearer token' do
+          expect(WebMock).to have_requested(:post, 'https://uat.icasework.com/token?db=hmcts').with(
+            headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
+            body: 'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzb21lX29wdGljc19hcGlfa2V5IiwiYXVkIjoiaHR0cHM6Ly91YXQuaWNhc2V3b3JrLmNvbS90b2tlbj9kYj1obWN0cyIsImlhdCI6MTU2ODIxNjA4Nn0.fj8VsMONpeEmeavkh23yRsGAtfVlWkJI267gijpy6pA'
+          ).once
+        end
+
+        it 'posts the submission to Optics' do
+          expect(WebMock).to have_requested(:post, 'https://uat.icasework.com/createcase?db=hmcts').with(
+            headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer some_bearer_token', 'Content-Type'=>'application/json', 'User-Agent'=>'Ruby'},
+            body: '{"Team":"111","AssignedTeam":"111","AssignedTeamSS":"111","RequestDate":"2019-09-11","Details":"","Reference":"","db":"hmcts","Type":"Complaint","Format":"json","RequestMethod":"Online - gov.uk","PartyContextManageCases":"Main","Customer.FirstName":"","Customer.Surname":"","Customer.Address":"","Customer.Town":"","Customer.County":"","Customer.Postcode":"","Customer.Email":"","Customer.Phone":"","Impact":"","ActionRequested":"","Document1.Name":"image.png","Document1.MimeType":"image/png","Document1.URL":"https://example.com/v1/attachments/e2161d54-92f8-4e10-b3a1-94630c65df3c","Document1.URLLoadContent":true}'
+          ).once
+        end
+
+        it 'records that there was a successful submission' do
+          expect(ProcessedSubmission.count).to eq(1)
+          expect(
+            ProcessedSubmission.first.submission_id
+          ).to eq('72c49803-e9c3-42ac-bde1-09c04595a2d3')
+        end
       end
   end
 end

--- a/spec/requests/complaint_spec.rb
+++ b/spec/requests/complaint_spec.rb
@@ -65,7 +65,7 @@ describe 'Submitting a complaint', type: :request do
 
   let(:runner_submission) do
     {
-      serviceSlug: 'claim-for-the-costs-of-a-something',
+      serviceSlug: 'complain-about-a-court-or-tribunal',
       submissionId: '891c837c-adef-4854-8bd0-d681577f381e',
       submissionAnswers:
       {

--- a/spec/requests/feedback_spec.rb
+++ b/spec/requests/feedback_spec.rb
@@ -9,45 +9,6 @@ describe 'Submitting feedback', type: :request do
     allow(SecureRandom).to receive(:uuid).and_return(
       'e2161d54-92f8-4e10-b3a1-94630c65df3c'
     )
-
-    stub_request(:post, 'https://uat.icasework.com/token?db=hmcts')
-    .with(
-      body: {
-        'assertion' => 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzb21lX29wdGljc19hcGlfa2V5IiwiYXVkIjoiaHR0cHM6Ly91YXQuaWNhc2V3b3JrLmNvbS90b2tlbj9kYj1obWN0cyIsImlhdCI6MTY1MTY3ODQ4Nn0.7f-8HNHcxUK5KV6K5yWUf5C7krkjNANv6it6ADa33FY', 'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer'
-      },
-      headers: {
-        'Accept'=>'*/*',
-        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-        'Content-Type'=>'application/x-www-form-urlencoded',
-        'User-Agent'=>'Ruby'
-        }
-      ).to_return(
-        status: 200,
-        body: {
-          access_token: 'some_bearer_token'
-        }.to_json, headers: {}
-      )
-
-    stub_request(:post, 'https://uat.icasework.com/createcase?db=hmcts')
-      .with(
-        body: expected_optics_payload,
-        headers: {
-          'Accept'=>'*/*',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Bearer some_bearer_token',
-          'Content-Type'=>'application/json',
-          'User-Agent'=>'Ruby'
-        }
-      )
-      .to_return(
-        {
-          status: 200,
-          body: 'stub case id response',
-          headers: {
-            'Content-Type'=>'application/x-www-form-urlencoded'
-          }
-        }
-      )
   end
 
   let(:expected_optics_payload) do
@@ -69,6 +30,45 @@ describe 'Submitting feedback', type: :request do
 
   context 'from legacy formbuilder v1' do
     before do
+      stub_request(:post, 'https://uat.icasework.com/token?db=hmcts')
+      .with(
+        body: {
+          'assertion' => 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzb21lX29wdGljc19hcGlfa2V5IiwiYXVkIjoiaHR0cHM6Ly91YXQuaWNhc2V3b3JrLmNvbS90b2tlbj9kYj1obWN0cyIsImlhdCI6MTY1MTY3ODQ4Nn0.7f-8HNHcxUK5KV6K5yWUf5C7krkjNANv6it6ADa33FY', 'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer'
+        },
+        headers: {
+          'Accept'=>'*/*',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Content-Type'=>'application/x-www-form-urlencoded',
+          'User-Agent'=>'Ruby'
+          }
+        ).to_return(
+          status: 200,
+          body: {
+            access_token: 'some_bearer_token'
+          }.to_json, headers: {}
+        )
+
+      stub_request(:post, 'https://uat.icasework.com/createcase?db=hmcts')
+        .with(
+          body: expected_optics_payload,
+          headers: {
+            'Accept'=>'*/*',
+            'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Authorization'=>'Bearer some_bearer_token',
+            'Content-Type'=>'application/json',
+            'User-Agent'=>'Ruby'
+          }
+        )
+        .to_return(
+          {
+            status: 200,
+            body: 'stub case id response',
+            headers: {
+              'Content-Type'=>'application/x-www-form-urlencoded'
+            }
+          }
+        )
+
       perform_enqueued_jobs do
         post '/v1/feedback', params: encrypted_body(msg: runner_submission)
       end
@@ -135,6 +135,36 @@ describe 'Submitting feedback', type: :request do
     end
 
     before do
+      stub_request(:post, "https://uat.icasework.com/createcase?db=hmcts").
+      with(
+        body: "{\"Type\":\"UF144908\",\"RequestDate\":\"2022-05-04\",\"RequestMethod\":\"Online form\",\"External.RequestDate\":\"2022-05-04\",\"External.RequestMethod\":\"Online form\",\"PartyContext\":\"Main\",\"AssignedTeam\":\"\",\"Details\":\"\"}",
+        headers: {
+        'Accept'=>'*/*',
+        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'Authorization'=>'Bearer some_bearer_token',
+        'Content-Type'=>'application/json',
+        'User-Agent'=>'Ruby'
+        }).
+      to_return(status: 200, body: "", headers: {})
+
+      stub_request(:post, 'https://uat.icasework.com/token?db=hmcts')
+      .with(
+        body: {
+          'assertion' => 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzb21lX29wdGljc19hcGlfa2V5IiwiYXVkIjoiaHR0cHM6Ly91YXQuaWNhc2V3b3JrLmNvbS90b2tlbj9kYj1obWN0cyIsImlhdCI6MTY1MTY3ODQ4Nn0.7f-8HNHcxUK5KV6K5yWUf5C7krkjNANv6it6ADa33FY', 'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer'
+        },
+        headers: {
+          'Accept'=>'*/*',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Content-Type'=>'application/x-www-form-urlencoded',
+          'User-Agent'=>'Ruby'
+          }
+        ).to_return(
+          status: 200,
+          body: {
+            access_token: 'some_bearer_token'
+          }.to_json, headers: {}
+        )
+
       perform_enqueued_jobs do
         post '/v2/feedback', params: encrypted_body(msg: runner_submission)
       end
@@ -146,6 +176,29 @@ describe 'Submitting feedback', type: :request do
 
     it 'returns 201 on a valid post' do
       expect(response).to have_http_status(:created)
+    end
+
+    describe 'end to end submission' do
+      it 'requests a bearer token' do
+        expect(WebMock).to have_requested(:post, 'https://uat.icasework.com/token?db=hmcts').with(
+          headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
+          body: 'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzb21lX29wdGljc19hcGlfa2V5IiwiYXVkIjoiaHR0cHM6Ly91YXQuaWNhc2V3b3JrLmNvbS90b2tlbj9kYj1obWN0cyIsImlhdCI6MTY1MTY3ODQ4Nn0.7f-8HNHcxUK5KV6K5yWUf5C7krkjNANv6it6ADa33FY'
+        ).once
+      end
+
+      it 'posts the submission to Optics' do
+        expect(WebMock).to have_requested(:post, 'https://uat.icasework.com/createcase?db=hmcts').with(
+          headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer some_bearer_token', 'Content-Type'=>'application/json', 'User-Agent'=>'Ruby'},
+          body: '{"Type":"UF144908","RequestDate":"2022-05-04","RequestMethod":"Online form","External.RequestDate":"2022-05-04","External.RequestMethod":"Online form","PartyContext":"Main","AssignedTeam":"","Details":""}'
+        ).once
+      end
+
+      it 'records that there was a successful submission' do
+        expect(ProcessedSubmission.count).to eq(1)
+        expect(
+          ProcessedSubmission.first.submission_id
+        ).to eq('72c49803-e9c3-42ac-bde1-09c04595a2d3')
+      end
     end
   end
 end

--- a/spec/requests/feedback_spec.rb
+++ b/spec/requests/feedback_spec.rb
@@ -68,7 +68,7 @@ describe 'Submitting feedback', type: :request do
 
   let(:runner_submission) do
     {
-      serviceSlug: 'user-feedback-form',
+      serviceSlug: 'user-feedback',
       submissionId: '891c837c-adef-4854-8bd0-d681577f381e',
       submissionAnswers:
       {

--- a/spec/requests/feedback_spec.rb
+++ b/spec/requests/feedback_spec.rb
@@ -67,7 +67,7 @@ describe 'Submitting feedback', type: :request do
     Timecop.return
   end
 
-  context 'legacy formbuilder v1' do
+  context 'from legacy formbuilder v1' do
     before do
       perform_enqueued_jobs do
         post '/v1/feedback', params: encrypted_body(msg: runner_submission)
@@ -120,4 +120,32 @@ describe 'Submitting feedback', type: :request do
       end
     end
   end
+
+  # context 'with mojforms v2 services' do
+  #   before do
+  #     perform_enqueued_jobs do
+  #       post '/v2/feedback', params: encrypted_body(msg: runner_submission)
+  #     end
+  #   end
+
+  #   let(:runner_submission) do
+  #     {
+  #       serviceSlug: 'hmcts-feedback-form-eng',
+  #       submissionId: '72c49803-e9c3-42ac-bde1-09c04595a2d3',
+  #       submissionAnswers:
+  #       {
+  #         whichpartofhmctswereyouincontactwith_autocomplete_1: '973',
+  #         telluswhatwedidwell_textarea_1: 'this is fab'
+  #       }
+  #     }.to_json
+  #   end
+
+  #   include_context 'when authentication required' do
+  #     let(:url) { '/v2/feedback' }
+  #   end
+
+  #   it 'returns 201 on a valid post' do
+  #     expect(response).to have_http_status(:created)
+  #   end
+  # end
 end

--- a/spec/requests/feedback_spec.rb
+++ b/spec/requests/feedback_spec.rb
@@ -120,4 +120,32 @@ describe 'Submitting feedback', type: :request do
       end
     end
   end
+
+  context 'with mojforms v2 services' do
+    let(:runner_submission) do
+      {
+        serviceSlug: 'hmcts-feedback-form-eng',
+        submissionId: '72c49803-e9c3-42ac-bde1-09c04595a2d3',
+        submissionAnswers:
+        {
+          whichpartofhmctswereyouincontactwith_autocomplete_1: '1111',
+          telluswhatwedidwell_textarea_1: 'all of the feedback'
+        }
+      }.to_json
+    end
+
+    before do
+      perform_enqueued_jobs do
+        post '/v2/feedback', params: encrypted_body(msg: runner_submission)
+      end
+    end
+
+    include_context 'when authentication required' do
+      let(:url) { '/v2/feedback' }
+    end
+
+    it 'returns 201 on a valid post' do
+      expect(response).to have_http_status(:created)
+    end
+  end
 end

--- a/spec/requests/feedback_spec.rb
+++ b/spec/requests/feedback_spec.rb
@@ -48,6 +48,7 @@ describe 'Submitting feedback', type: :request do
           }
         }
       )
+
   end
 
   let(:expected_optics_payload) do
@@ -120,32 +121,4 @@ describe 'Submitting feedback', type: :request do
       end
     end
   end
-
-  # context 'with mojforms v2 services' do
-  #   before do
-  #     perform_enqueued_jobs do
-  #       post '/v2/feedback', params: encrypted_body(msg: runner_submission)
-  #     end
-  #   end
-
-  #   let(:runner_submission) do
-  #     {
-  #       serviceSlug: 'hmcts-feedback-form-eng',
-  #       submissionId: '72c49803-e9c3-42ac-bde1-09c04595a2d3',
-  #       submissionAnswers:
-  #       {
-  #         whichpartofhmctswereyouincontactwith_autocomplete_1: '973',
-  #         telluswhatwedidwell_textarea_1: 'this is fab'
-  #       }
-  #     }.to_json
-  #   end
-
-  #   include_context 'when authentication required' do
-  #     let(:url) { '/v2/feedback' }
-  #   end
-
-  #   it 'returns 201 on a valid post' do
-  #     expect(response).to have_http_status(:created)
-  #   end
-  # end
 end

--- a/spec/requests/feedback_spec.rb
+++ b/spec/requests/feedback_spec.rb
@@ -48,7 +48,6 @@ describe 'Submitting feedback', type: :request do
           }
         }
       )
-
   end
 
   let(:expected_optics_payload) do

--- a/spec/requests/feedback_spec.rb
+++ b/spec/requests/feedback_spec.rb
@@ -48,9 +48,6 @@ describe 'Submitting feedback', type: :request do
           }
         }
       )
-    perform_enqueued_jobs do
-      post '/v1/feedback', params: encrypted_body(msg: runner_submission)
-    end
   end
 
   let(:expected_optics_payload) do
@@ -66,53 +63,61 @@ describe 'Submitting feedback', type: :request do
     }.to_json
   end
 
-  let(:runner_submission) do
-    {
-      serviceSlug: 'user-feedback',
-      submissionId: '891c837c-adef-4854-8bd0-d681577f381e',
-      submissionAnswers:
-      {
-        contact_location: '1111',
-        feedback_details: 'all of the feedback'
-      }
-    }.to_json
-  end
-
   after do
     Timecop.return
   end
 
-  include_context 'when authentication required' do
-    let(:url) { '/v1/feedback' }
-  end
-
-  it 'returns 201 on a valid post' do
-    expect(response).to have_http_status(:created)
-  end
-
-  describe 'end to end submission' do
-    it 'requests a bearer token' do
-      expect(WebMock).to have_requested(:post, 'https://uat.icasework.com/token?db=hmcts').with(
-        headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
-        body: 'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzb21lX29wdGljc19hcGlfa2V5IiwiYXVkIjoiaHR0cHM6Ly91YXQuaWNhc2V3b3JrLmNvbS90b2tlbj9kYj1obWN0cyIsImlhdCI6MTY1MTY3ODQ4Nn0.7f-8HNHcxUK5KV6K5yWUf5C7krkjNANv6it6ADa33FY'
-      ).once
+  context 'legacy formbuilder v1' do
+    before do
+      perform_enqueued_jobs do
+        post '/v1/feedback', params: encrypted_body(msg: runner_submission)
+      end
     end
 
-    it 'posts the submission to Optics' do
-      expect(WebMock).to have_requested(:post, 'https://uat.icasework.com/createcase?db=hmcts').with(
-        headers: {
-          'Authorization' => 'Bearer some_bearer_token',
-          'Content-Type' => 'application/json'
-        },
-        body: expected_optics_payload
-      ).once
+    let(:runner_submission) do
+      {
+        serviceSlug: 'user-feedback',
+        submissionId: '891c837c-adef-4854-8bd0-d681577f381e',
+        submissionAnswers:
+        {
+          contact_location: '1111',
+          feedback_details: 'all of the feedback'
+        }
+      }.to_json
     end
 
-    it 'records that there was a successful submission' do
-      expect(ProcessedSubmission.count).to eq(1)
-      expect(
-        ProcessedSubmission.first.submission_id
-      ).to eq('891c837c-adef-4854-8bd0-d681577f381e')
+    include_context 'when authentication required' do
+      let(:url) { '/v1/feedback' }
+    end
+
+    it 'returns 201 on a valid post' do
+      expect(response).to have_http_status(:created)
+    end
+
+    describe 'end to end submission' do
+      it 'requests a bearer token' do
+        expect(WebMock).to have_requested(:post, 'https://uat.icasework.com/token?db=hmcts').with(
+          headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
+          body: 'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzb21lX29wdGljc19hcGlfa2V5IiwiYXVkIjoiaHR0cHM6Ly91YXQuaWNhc2V3b3JrLmNvbS90b2tlbj9kYj1obWN0cyIsImlhdCI6MTY1MTY3ODQ4Nn0.7f-8HNHcxUK5KV6K5yWUf5C7krkjNANv6it6ADa33FY'
+        ).once
+      end
+
+      it 'posts the submission to Optics' do
+        expect(WebMock).to have_requested(:post, 'https://uat.icasework.com/createcase?db=hmcts').with(
+          headers: {
+            'Authorization' => 'Bearer some_bearer_token',
+            'Content-Type' => 'application/json'
+          },
+          body: expected_optics_payload
+        ).once
+      end
+
+      it 'records that there was a successful submission' do
+        expect(ProcessedSubmission.count).to eq(1)
+        expect(
+          ProcessedSubmission.first.submission_id
+        ).to eq('891c837c-adef-4854-8bd0-d681577f381e')
+      end
     end
   end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/b5rYJeVy/3510-api-submission-adapter-updates)

## Context
We have implemented the api submission for the submitter in order to migrate HMCTS Complaints and Correspondence forms. We have to update the adapter to OPTICS so it sends the right payload.

## Change
This is to add the routes for v2 endpoints for complaints, comments and feedback forms. It is using same processing as for legacy, except for a couple of fields that don't have the same name.  For example feedback_details in feedback formbuilder is telluswhatwedidwell_textarea_1 in feedback moj forms. This adapter will need to be updated if the form was changing, if for example a field was added or modified because the fields names are hard-coded.

## Tests
Automated tests have been updated. Manual testing with observation on the UAT (Optics UI) have been done. Those tests have been performed with Charlotte from HMCTS, PM for OPTICS.