### PR TITLE
Add prometheus rules (moved from fb-monitoring)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,7 @@ workflows:
             branches:
               only:
                 - master
+                - prometheus-rules
       - build_worker_image:
           context: *context
           requires:
@@ -175,6 +176,7 @@ workflows:
             branches:
               only:
                 - master
+                - prometheus-rules
       - deploy_to_staging:
           context: *context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,6 @@ workflows:
             branches:
               only:
                 - master
-                - prometheus-rules
       - build_worker_image:
           context: *context
           requires:
@@ -176,7 +175,6 @@ workflows:
             branches:
               only:
                 - master
-                - prometheus-rules
       - deploy_to_staging:
           context: *context
           requires:

--- a/deploy-eks/hmcts-complaints-formbuilder-adapter-chart/templates/prometheus.yml
+++ b/deploy-eks/hmcts-complaints-formbuilder-adapter-chart/templates/prometheus.yml
@@ -12,7 +12,7 @@ spec:
     rules:
     - alert: KubePodNotReady
       annotations:
-        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than 10 minutes
+        message: Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}} has been in a non-ready state for longer than 10 minutes
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
       expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase!~"Running|Succeeded", namespace="hmcts-complaints-formbuilder-adapter-{{ .Values.environmentName }}"}) > 0
       for: 10m
@@ -21,7 +21,7 @@ spec:
 
     - alert: KubePodCrashLooping
       annotations:
-        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting excessively
+        message: Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}} ({{`{{`}} $labels.container {{`}}`}}) is restarting excessively
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping
       expr: rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="hmcts-complaints-formbuilder-adapter-{{ .Values.environmentName }}"}[10m]) > 0
       for: 5m
@@ -30,7 +30,7 @@ spec:
 
     - alert: DeploymentReplicasMismatch
       annotations:
-        message: Deployment `{{ $labels.deployment }}` has not matched the expected number of replicas for more than 30m.
+        message: Deployment `{{`{{`}} $labels.deployment {{`}}`}}` has not matched the expected number of replicas for more than 30m.
       expr: >-
         kube_deployment_spec_replicas{job="kube-state-metrics", namespace="hmcts-complaints-formbuilder-adapter-{{ .Values.environmentName }}"}
         != kube_deployment_status_replicas_available{job="kube-state-metrics"}
@@ -40,7 +40,7 @@ spec:
 
     - alert: KubeNamespaceQuotaNearing
       annotations:
-        message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value }}% of its {{ $labels.resource }} quota.
+        message: Namespace {{`{{`}} $labels.namespace {{`}}`}} is using {{`{{`}} printf "%0.0f" $value {{`}}`}}% of its {{`{{`}} $labels.resource {{`}}`}} quota.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
       expr: |-
         100 * kube_resourcequota{job="kube-state-metrics", type="used", namespace="hmcts-complaints-formbuilder-adapter-{{ .Values.environmentName }}"}

--- a/deploy-eks/hmcts-complaints-formbuilder-adapter-chart/templates/prometheus.yml
+++ b/deploy-eks/hmcts-complaints-formbuilder-adapter-chart/templates/prometheus.yml
@@ -1,0 +1,62 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  namespace: hmcts-complaints-formbuilder-adapter-{{ .Values.environmentName }}
+  name: prometheus-rules
+  labels:
+    role: alert-rules
+    prometheus: cloud-platform
+spec:
+  groups:
+  - name: hmcts-adapter
+    rules:
+    - alert: KubePodNotReady
+      annotations:
+        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than 10 minutes
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
+      expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase!~"Running|Succeeded", namespace="hmcts-complaints-formbuilder-adapter-{{ .Values.environmentName }}"}) > 0
+      for: 10m
+      labels:
+        severity: {{ .Values.prometheus.alertSeverity }}
+
+    - alert: KubePodCrashLooping
+      annotations:
+        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting excessively
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping
+      expr: rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="hmcts-complaints-formbuilder-adapter-{{ .Values.environmentName }}"}[10m]) > 0
+      for: 5m
+      labels:
+        severity: {{ .Values.prometheus.alertSeverity }}
+
+    - alert: DeploymentReplicasMismatch
+      annotations:
+        message: Deployment `{{ $labels.deployment }}` has not matched the expected number of replicas for more than 30m.
+      expr: >-
+        kube_deployment_spec_replicas{job="kube-state-metrics", namespace="hmcts-complaints-formbuilder-adapter-{{ .Values.environmentName }}"}
+        != kube_deployment_status_replicas_available{job="kube-state-metrics"}
+      for: 30m
+      labels:
+        severity: {{ .Values.prometheus.alertSeverity }}
+
+    - alert: KubeNamespaceQuotaNearing
+      annotations:
+        message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value }}% of its {{ $labels.resource }} quota.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
+      expr: |-
+        100 * kube_resourcequota{job="kube-state-metrics", type="used", namespace="hmcts-complaints-formbuilder-adapter-{{ .Values.environmentName }}"}
+          / ignoring(instance, job, type)
+        (kube_resourcequota{job="kube-state-metrics", type="hard", namespace="hmcts-complaints-formbuilder-adapter-{{ .Values.environmentName }}"} > 0)
+          > 90
+      for: 5m
+      labels:
+        severity: {{ .Values.prometheus.alertSeverity }}
+
+    - alert: FailedDelayedJobs
+      annotations:
+        message: A HMCTS Adapter Delayed job has failed in {{ .Values.environmentName }}
+        runbook_url: https://ministryofjustice.github.io/fb-guide-and-runbook/troubleshooting/find-a-failed-submission/#delayed-job-failures
+      expr: |-
+        avg(delayed_jobs_failed{namespace="hmcts-complaints-formbuilder-adapter-{{ .Values.environmentName }}"}) > 0
+      for: 1m
+      labels:
+        severity: {{ .Values.prometheus.alertSeverity }}


### PR DESCRIPTION
These rules were in the `fb-monitoring` and applied there with custom scripts and the need to have 2 eks tokens one for staging and another for production.

It seems more appropriate to have these rules in the application repo.

If this works, the rules will be deleted from the fb-monitoring repo.